### PR TITLE
Transfered the `lm-evaluation-harness` fork  we use to the Organization

### DIFF
--- a/evals/eval_harness_bn.sh
+++ b/evals/eval_harness_bn.sh
@@ -45,7 +45,7 @@ source $workdir/.venv_eval_bengali/bin/activate  # <-- Activate the virtual envi
 
 # UNCOMMENT the following lines on first run to set up lm-evaluation-harness:
 # This is our fork of the lm-evaluation-harness with Bengali tasks added
-# git clone --branch polyglot_harness_bengali https://github.com/Nkluge-correa/lm-evaluation-harness.git
+# git clone --branch polyglot_harness_bengali https://github.com/Polygl0t/lm-evaluation-harness.git
 # mv $workdir/lm-evaluation-harness $workdir/lm_evaluation_harness_bengali
 # pip3 install -e $workdir/lm_evaluation_harness_bengali
 # pip3 install "lm_eval[hf,vllm]"          # <-- Install lm-eval with HuggingFace and vLLM support

--- a/evals/eval_harness_pt_new.sh
+++ b/evals/eval_harness_pt_new.sh
@@ -45,7 +45,7 @@ source $workdir/.venv_eval_pt/bin/activate  # <-- Activate the virtual environme
 
 # UNCOMMENT the following lines on first run to set up lm-evaluation-harness:
 # This is our fork of the lm-evaluation-harness with Portuguese tasks added
-# git clone --branch polyglot_harness_portuguese https://github.com/Nkluge-correa/lm-evaluation-harness.git
+# git clone --branch polyglot_harness_portuguese https://github.com/Polygl0t/lm-evaluation-harness.git
 # mv $workdir/lm-evaluation-harness $workdir/lm_evaluation_harness
 # pip3 install -e $workdir/lm_evaluation_harness
 # pip3 install "lm_eval[hf,vllm]"          # <-- Install lm-eval with HuggingFace and vLLM support


### PR DESCRIPTION
The fork we used from the [`lm-evaluation-harness`](https://github.com/Polygl0t/lm-evaluation-harness) is now under the org. Evaluation scripts should use this fork's source from now on.