### PR TITLE
Organizing Variables and other minor updates (are Baners cool?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Polyglot
+<pre>
+██████╗  ██████╗ ██╗  ██╗   ██╗ ██████╗  ██████╗ ████████╗
+██╔══██╗██╔═══██╗██║  ╚██╗ ██╔╝██╔════╝ ██╔═████╗╚══██╔══╝
+██████╔╝██║   ██║██║   ╚████╔╝ ██║  ███╗██║██╔██║   ██║   
+██╔═══╝ ██║   ██║██║    ╚██╔╝  ██║   ██║████╔╝██║   ██║   
+██║     ╚██████╔╝███████╗██║   ╚██████╔╝╚██████╔╝   ██║   
+╚═╝      ╚═════╝ ╚══════╝╚═╝    ╚═════╝  ╚═════╝    ╚═╝   
+<pre>
 
 Developing foundation models for low-resource languages.
 
@@ -22,4 +29,3 @@ You can use the `installation.sh` script to set up a new working environment on 
 Polyglot is a project funded by the Federal Ministry of Education and Research (BMBF) and the Ministry of Culture and Science of the State of North Rhine-Westphalia (MWK) as part of TRA Sustainable Futures (University of Bonn) and the Excellence Strategy of the federal and state governments.
 
 We also gratefully acknowledge the granted access to the [Marvin cluster](https://www.hpc.uni-bonn.de/en/systems/marvin) hosted by [University of Bonn](https://www.uni-bonn.de/en) along with the support provided by its High Performance Computing & Analytics Lab.
-

--- a/ddp/train_ddp.sh
+++ b/ddp/train_ddp.sh
@@ -69,13 +69,10 @@ export TORCH_DISTRIBUTED_DEBUG=OFF
 export NCCL_IB_TIMEOUT=20
 export NCCL_IB_RETRY_CNT=7
 #export NCCL_DEBUG=INFO # Uncomment for NCCL debugging
-
-# Set MASTER_ADDR and MASTER_PORT for distributed training
-MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n 1)"
-export MASTER_ADDR="$(nslookup "$MASTER_ADDR" | grep -oP '(?<=Address: ).*')"
-export MASTER_PORT=12340
-
-SPECS_FILE="$workdir/ddp/train_config.yaml"
+MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n 1)" # <-- Get the master node address
+export MASTER_ADDR="$(nslookup "$MASTER_ADDR" | grep -oP '(?<=Address: ).*')" # <-- Resolve to IP address
+export MASTER_PORT=12340 # <-- Ensure this port is open in your SLURM cluster
+export SPECS_FILE="$workdir/ddp/train_config.yaml"  # <-- Change to your specs file path
 
 echo "# [${SLURM_JOB_ID}] Job started at: $(date)" > "$out"
 echo "# [${SLURM_JOB_ID}] Using $SLURM_NNODES node(s)" >> "$out"

--- a/dpo/dpo_trainer.py
+++ b/dpo/dpo_trainer.py
@@ -158,7 +158,7 @@ def main(args):
         attn_implementation=args.attn_implementation,
         dtype=dtype,
         trust_remote_code=True,
-        device_map={'': accelerate.PartialState().process_index},
+        device_map={'': state.process_index},
         use_cache=False if args.gradient_checkpointing else True,
     )
     

--- a/fsdp/train_fsdp.sh
+++ b/fsdp/train_fsdp.sh
@@ -69,13 +69,10 @@ export TORCH_DISTRIBUTED_DEBUG=OFF
 export NCCL_IB_TIMEOUT=20
 export NCCL_IB_RETRY_CNT=7
 #export NCCL_DEBUG=INFO # Uncomment for NCCL debugging
-
-# Set MASTER_ADDR and MASTER_PORT for distributed training
-MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n 1)"
-export MASTER_ADDR="$(nslookup "$MASTER_ADDR" | grep -oP '(?<=Address: ).*')"
-export MASTER_PORT=12340
-
-SPECS_FILE="$workdir/fsdp/train_config.yaml"
+MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n 1)" # <-- Get the master node address
+export MASTER_ADDR="$(nslookup "$MASTER_ADDR" | grep -oP '(?<=Address: ).*')" # <-- Resolve to IP address
+export MASTER_PORT=12340 # <-- Ensure this port is open in your SLURM cluster
+export SPECS_FILE="$workdir/fsdp/train_config.yaml"  # <-- Change to your specs file path
 
 echo "# [${SLURM_JOB_ID}] Job started at: $(date)" > "$out"
 echo "# [${SLURM_JOB_ID}] Using $SLURM_NNODES node(s)" >> "$out"

--- a/long_ctx/train_hf.py
+++ b/long_ctx/train_hf.py
@@ -91,7 +91,7 @@ def main(args):
         "attn_implementation": args.attn_implementation,
         "dtype": torch.bfloat16 if args.bf16 else torch.float32,
         "trust_remote_code": True,
-        "device_map":{'':accelerate.PartialState().process_index},
+        "device_map":{'':state.process_index},
         "use_cache": False if args.gradient_checkpointing else True,  # Disable cache if using gradient checkpointing
     }
 

--- a/sft/sft_trainer.py
+++ b/sft/sft_trainer.py
@@ -199,7 +199,7 @@ def main(args):
             "attn_implementation": args.attn_implementation,
             "dtype": torch.bfloat16 if args.bf16 else torch.float32,
             "trust_remote_code": True,
-            "device_map":{'':accelerate.PartialState().process_index},
+            "device_map":{'':state.process_index},
             "use_cache": False if args.gradient_checkpointing else True,  # Disable cache if using gradient checkpointing
         },
         output_dir=args.checkpoint_dir,


### PR DESCRIPTION
Here are the mods:

* Added clarifying comments to the setup of `MASTER_ADDR`, `MASTER_PORT`, and `SPECS_FILE` in both `ddp/train_ddp.sh` and `fsdp/train_fsdp.sh` to make the distributed training configuration more understandable and maintainable.

* Updated the usage of `device_map` in `dpo/dpo_trainer.py`, `long_ctx/train_hf.py`, and `sft/sft_trainer.py` to use `state.process_index` instead of `accelerate.PartialState().process_index`, to avoid the redundant call to another init of a distributed process.

* Added an ASCII art logo at the top of the README file (cosmetics!!!)