### PR TITLE
Minor improvments for SFT and APO post-training set up.

### DIFF
--- a/data/cc/process_cc_dump.py
+++ b/data/cc/process_cc_dump.py
@@ -20,7 +20,7 @@ Stage 2 - Quality Filtering (per-language):
 4. FineWeb Quality Filter (punctuation, newlines, char duplicates)
 5. Gopher Quality Filter (word length, stop words, alpha ratio)
 6. Formatting cleanup (FTFY encoding fixes, PII removal, symbol lines)
-7. Token counting with custom tokenizer
+7. Token counting with a selected tokenizer (default: Qwen/Qwen3-0.6B)
 8. Output to final JSONL files
 
 Supported languages (configurable):
@@ -326,9 +326,6 @@ def main(args):
                     exclusion_writer=None,
                 ),
 
-                # [TokensCounter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/tokens/counter.py#L7)
-                TokensCounter(tokenizer_name_or_path=TOKENIZER_NAME_OR_PATH),
-
                 #[formatters: FTFYFormatter, PIIFormatter, SymbolLinesFormatter](https://github.com/huggingface/datatrove/tree/main/src/datatrove/pipeline/formatters)
                 # [FTFYFormatter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/formatters/ftfy.py)
                 FTFYFormatter(),  # Fix encoding issues. Important in a multilingual setting!
@@ -340,6 +337,9 @@ def main(args):
                 # [SymbolLinesFormatter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/formatters/symbol_lines_remover.py)
                 # Removes lines that consist exclusively of symbols. Keeps lines that only have whitespace characters.
                 SymbolLinesFormatter(symbols_to_remove=["|"], replace_char="\n"),
+
+                # [TokensCounter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/tokens/counter.py#L7)
+                TokensCounter(tokenizer_name_or_path=TOKENIZER_NAME_OR_PATH),
 
                 # [writers: JsonlWriter, ParquetWriter, HuggingFaceDatasetWriter](https://github.com/huggingface/datatrove/tree/main/src/datatrove/pipeline/writers)
                 # [JsonlWriter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/writers/jsonl.py)

--- a/data/filters/quality_filters.py
+++ b/data/filters/quality_filters.py
@@ -194,9 +194,6 @@ def main(args):
                 exclusion_writer=None,
             ),
 
-            # [TokensCounter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/tokens/counter.py#L7)
-            TokensCounter(tokenizer_name_or_path=TOKENIZER_NAME_OR_PATH),
-
             ##[formatters: FTFYFormatter, PIIFormatter, SymbolLinesFormatter](https://github.com/huggingface/datatrove/tree/main/src/datatrove/pipeline/formatters)
             # [FTFYFormatter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/formatters/ftfy.py)
             FTFYFormatter(),  # Fix encoding issues. Important in a multilingual setting!
@@ -208,6 +205,9 @@ def main(args):
             # [SymbolLinesFormatter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/formatters/symbol_lines_remover.py)
             # Removes lines that consist exclusively of symbols. Keeps lines that only have whitespace characters.
             SymbolLinesFormatter(symbols_to_remove=["|"], replace_char="\n"),
+
+            # [TokensCounter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/tokens/counter.py#L7)
+            TokensCounter(tokenizer_name_or_path=TOKENIZER_NAME_OR_PATH),
 
             # [writers: JsonlWriter, ParquetWriter, HuggingFaceDatasetWriter](https://github.com/huggingface/datatrove/tree/main/src/datatrove/pipeline/writers)
             # [JsonlWriter](https://github.com/huggingface/datatrove/blob/main/src/datatrove/pipeline/writers/jsonl.py)

--- a/data/filters/sft_filters.py
+++ b/data/filters/sft_filters.py
@@ -24,6 +24,7 @@ Usage Examples:
         --input_type parquet \
         --output_type parquet \
         --messages_column messages \
+        --token_count_column token_count \
         --filter_incomplete_sentences \
         --filter_malformed_code_blocks \
         --filter_corrupted_code \
@@ -438,19 +439,20 @@ def filter_repetition_loops(example, messages_column="messages",
     return True
 
 
-def filter_minimum_tokens(example, min_tokens):
+def filter_minimum_tokens(example, min_tokens, token_count_column="token_count"):
     """
     Filter out samples below the minimum token count threshold.
     
     Args:
-        example: A dataset sample with a 'token_count' field.
+        example: A dataset sample with a token count field.
         min_tokens: Minimum number of tokens required.
+        token_count_column: Name of the column containing token counts.
     
     Returns:
         bool: True if sample meets the threshold, False otherwise.
     """
     try:
-        token_count = example.get("token_count", 0)
+        token_count = example.get(token_count_column, 0)
         return token_count >= min_tokens
     except (KeyError, TypeError):
         return False
@@ -584,19 +586,20 @@ def filter_incomplete_sentences(example, messages_column="messages"):
         return False
 
 
-def filter_token_count(example, max_tokens):
+def filter_token_count(example, max_tokens, token_count_column="token_count"):
     """
     Filter out samples exceeding the maximum token count threshold.
     
     Args:
-        example: A dataset sample with a 'token_count' field.
+        example: A dataset sample with a token count field.
         max_tokens: Maximum number of tokens allowed.
+        token_count_column: Name of the column containing token counts.
     
     Returns:
         bool: True if sample is within the limit, False otherwise.
     """
     try:
-        token_count = example.get("token_count", 0)
+        token_count = example.get(token_count_column, 0)
         return token_count <= max_tokens
     except (KeyError, TypeError):
         return False
@@ -634,7 +637,7 @@ def load_dataset(input_dir, input_type="jsonl", cache_dir=None):
     return dataset, len(data_files)
 
 
-def plot_token_distribution(dataset, output_dir):
+def plot_token_distribution(dataset, output_dir, token_count_column="token_count"):
     """
     Generate and save a histogram of the token count distribution.
     
@@ -642,17 +645,18 @@ def plot_token_distribution(dataset, output_dir):
     and saves it as a PNG file in the output directory.
     
     Args:
-        dataset: The filtered dataset with a 'token_count' column.
+        dataset: The filtered dataset with a token count column.
         output_dir: Directory where the histogram will be saved.
+        token_count_column: Name of the column containing token counts.
     
     Note:
-        Skips if 'token_count' column is not present in the dataset.
+        Skips if token count column is not present in the dataset.
     """
-    if "token_count" not in dataset.column_names:
-        print("[WARNING] 'token_count' column not found. Skipping histogram.")
+    if token_count_column not in dataset.column_names:
+        print(f"[WARNING] '{token_count_column}' column not found. Skipping histogram.")
         return
     
-    token_counts = dataset["token_count"]
+    token_counts = dataset[token_count_column]
     
     # Create figure
     plt.figure(figsize=(12, 6))
@@ -749,8 +753,9 @@ def main(args):
     assert args.input_type in ["jsonl", "parquet"], "Input type must be either 'jsonl' or 'parquet'."
     assert args.output_type in ["jsonl", "parquet"], "Output type must be either 'jsonl' or 'parquet'."
     
-    # Get the messages column name
+    # Get the column names
     messages_column = args.messages_column
+    token_count_column = args.token_count_column
     
     # Load dataset
     print(f"[INFO] Loading dataset from {args.input_dir}")
@@ -859,18 +864,18 @@ def main(args):
         else:
             print(f"[WARNING] Quality score column '{args.quality_score_column}' not found in dataset. Skipping filter.")
     
-    if args.min_token_count is not None and "token_count" in dataset.column_names:
-        print(f"[INFO] Filtering samples with token_count < {args.min_token_count:,}...")
+    if args.min_token_count is not None and token_count_column in dataset.column_names:
+        print(f"[INFO] Filtering samples with {token_count_column} < {args.min_token_count:,}...")
         before_filter = len(dataset)
-        dataset = dataset.filter(lambda x: filter_minimum_tokens(x, args.min_token_count), num_proc=args.num_proc)
+        dataset = dataset.filter(lambda x: filter_minimum_tokens(x, args.min_token_count, token_count_column), num_proc=args.num_proc)
         filtered_count = before_filter - len(dataset)
         print(f"[INFO] Removed {filtered_count:,} samples below minimum token threshold")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
     
-    if args.max_token_count and "token_count" in dataset.column_names:
-        print(f"[INFO] Filtering samples with token_count > {args.max_token_count:,}...")
+    if args.max_token_count and token_count_column in dataset.column_names:
+        print(f"[INFO] Filtering samples with {token_count_column} > {args.max_token_count:,}...")
         before_token_filter = len(dataset)
-        dataset = dataset.filter(lambda x: filter_token_count(x, args.max_token_count), num_proc=args.num_proc)
+        dataset = dataset.filter(lambda x: filter_token_count(x, args.max_token_count, token_count_column), num_proc=args.num_proc)
         filtered_tokens = before_token_filter - len(dataset)
         print(f"[INFO] Removed {filtered_tokens:,} samples exceeding token limit")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
@@ -882,8 +887,8 @@ def main(args):
     
     # Calculate total tokens if available
     total_tokens = None
-    if "token_count" in dataset.column_names:
-        total_tokens = sum(dataset["token_count"])
+    if token_count_column in dataset.column_names:
+        total_tokens = sum(dataset[token_count_column])
         print(f"[INFO] Total tokens in filtered dataset: {total_tokens:,}")
     
     # Determine number of chunks based on total tokens after filtering
@@ -906,7 +911,7 @@ def main(args):
     
     # Plot token distribution
     print(f"\n[INFO] Generating token distribution histogram...")
-    plot_token_distribution(dataset, args.output_dir)
+    plot_token_distribution(dataset, args.output_dir, token_count_column)
     
     print(f"\n[SUCCESS] Dataset saved to {args.output_dir}")
     print(f"[SUCCESS] Total samples: {len(dataset):,}")
@@ -953,6 +958,10 @@ if __name__ == "__main__":
     # Messages column configuration
     parser.add_argument("--messages_column", type=str, default="messages",
                         help="Name of the column containing the messages/conversation data (default: 'messages')")
+    
+    # Token count column configuration
+    parser.add_argument("--token_count_column", type=str, default="token_count",
+                        help="Name of the column containing token counts (default: 'token_count')")
     
     # Number of processes to use for parallel filtering
     parser.add_argument("--num_proc", type=int, default=4, help="Number of processes to use for filtering (default: 4)")

--- a/data/filters/sft_filters.py
+++ b/data/filters/sft_filters.py
@@ -3,11 +3,12 @@ SFT Dataset Filter
 
 A comprehensive filtering and conversion tool for instruction-tuning (SFT) datasets.
 Designed to clean, validate, and transform instruction-following datasets by removing
-malformed code blocks, corrupted code content, undecoded Unicode sequences, and other
-crap that passed trough the quality filter.
+malformed code blocks, corrupted code content, undecoded Unicode sequences, word
+repetition loops (degenerate model outputs), and other issues that passed through 
+the quality filter.
 
 Expected Dataset Format:
-The script expects datasets with a 'messages' column containing conversation data:
+The script expects datasets with a messages column (configurable) containing conversation data:
     {
         "messages": [
             {"role": "user", "content": "..."},
@@ -22,13 +23,16 @@ Usage Examples:
         --output_dir ./filtered_data \
         --input_type parquet \
         --output_type parquet \
+        --messages_column messages \
         --filter_incomplete_sentences \
         --filter_malformed_code_blocks \
         --filter_corrupted_code \
         --filter_undecoded_sequences \
         --filter_invalid_markers \
+        --filter_repetition_loops \
         --remove_system_messages \
-        --max_tokens_per_chunk 100000000
+        --quality_score_column instruct_score \
+        --min_quality_score 4.5
 """
 import datasets
 import numpy as np
@@ -180,18 +184,19 @@ MISTRANSLATED_CODE_INDICATORS = re.compile(
 )
 
 
-def get_all_content(example):
+def get_all_content(example, messages_column="messages"):
     """
     Extract and concatenate all text content from a sample's messages.
     
     Args:
-        example: A dataset sample containing a 'messages' field with conversation data.
+        example: A dataset sample containing a messages field with conversation data.
+        messages_column: The name of the column containing messages.
     
     Returns:
         str: All message contents joined by newlines, or empty string if no content.
     """
     try:
-        messages = example.get("messages", [])
+        messages = example.get(messages_column, [])
         if not messages:
             return ""
         return "\n".join(msg.get("content", "") for msg in messages if msg.get("content"))
@@ -199,7 +204,7 @@ def get_all_content(example):
         return ""
 
 
-def filter_malformed_code_blocks(example):
+def filter_malformed_code_blocks(example, messages_column="messages"):
     """
     Filter out samples containing malformed code blocks.
     
@@ -209,11 +214,12 @@ def filter_malformed_code_blocks(example):
     
     Args:
         example: A dataset sample to validate.
+        messages_column: The name of the column containing messages.
     
     Returns:
         bool: True if sample is valid (should be kept), False if malformed.
     """
-    content = get_all_content(example)
+    content = get_all_content(example, messages_column)
     if not content:
         return True  # Keep empty samples (will be filtered by other rules)
     
@@ -248,7 +254,7 @@ def filter_malformed_code_blocks(example):
     return True
 
 
-def filter_corrupted_code_content(example):
+def filter_corrupted_code_content(example, messages_column="messages"):
     """
     Filter out samples with mistranslated code content.
     
@@ -260,11 +266,12 @@ def filter_corrupted_code_content(example):
     
     Args:
         example: A dataset sample to validate.
+        messages_column: The name of the column containing messages.
     
     Returns:
         bool: True if sample is valid (should be kept), False if corrupted.
     """
-    content = get_all_content(example)
+    content = get_all_content(example, messages_column)
     if not content:
         return True
     
@@ -284,7 +291,7 @@ def filter_corrupted_code_content(example):
     return True
 
 
-def filter_undecoded_sequences(example):
+def filter_undecoded_sequences(example, messages_column="messages"):
     """
     Filter out samples containing undecoded Unicode escape sequences.
     
@@ -296,11 +303,12 @@ def filter_undecoded_sequences(example):
     
     Args:
         example: A dataset sample to validate.
+        messages_column: The name of the column containing messages.
     
     Returns:
         bool: True if sample is valid (should be kept), False if contains escapes.
     """
-    content = get_all_content(example)
+    content = get_all_content(example, messages_column)
     if not content:
         return True
     
@@ -311,7 +319,7 @@ def filter_undecoded_sequences(example):
     return True
 
 
-def filter_invalid_structural_markers(example):
+def filter_invalid_structural_markers(example, messages_column="messages"):
     """
     Filter out samples containing invalid structural markers.
     
@@ -323,17 +331,109 @@ def filter_invalid_structural_markers(example):
     
     Args:
         example: A dataset sample to validate.
+        messages_column: The name of the column containing messages.
     
     Returns:
         bool: True if sample is valid (should be kept), False if contains markers.
     """
-    content = get_all_content(example)
+    content = get_all_content(example, messages_column)
     if not content:
         return True
     
     # Check for invalid structural markers
     if INVALID_MARKER_PATTERN.search(content):
         return False
+    
+    return True
+
+
+def filter_repetition_loops(example, messages_column="messages", 
+                            min_repeated_words=5, max_unique_ratio=0.3,
+                            window_size=50, min_window_matches=3):
+    """
+    Filter out samples where the model gets stuck in word repetition loops.
+    
+    Detects degenerate text patterns where the model repeatedly generates similar
+    words in sequence, typically adverbs, participles, or related terms.
+    Examples of repetitive patterns:
+    - "precisamente calculadamente programaticamente antecipadamente predeterminadamente"
+    - "consolidadas solidificadas fortalecidas reforçadas intensificadas ampliadas"
+    
+    The detection uses multiple heuristics:
+    1. Sliding window analysis: Checks for windows with low unique word ratio
+    2. Suffix pattern detection: Identifies long sequences of words with same suffix
+    3. N-gram repetition: Detects repeated word sequences
+    
+    Args:
+        example: A dataset sample to validate.
+        messages_column: The name of the column containing messages.
+        min_repeated_words: Minimum words in a sequence to check for repetition.
+        max_unique_ratio: Maximum ratio of unique words in a window to be flagged.
+        window_size: Size of sliding window for analysis.
+        min_window_matches: Minimum windows that must match to filter the sample.
+    
+    Returns:
+        bool: True if sample is valid (should be kept), False if contains repetition loops.
+    """
+    content = get_all_content(example, messages_column)
+    if not content:
+        return True
+    
+    # Tokenize into words (simple whitespace + punctuation split)
+    words = re.findall(r'\b[a-záàâãéèêíìîóòôõúùûüçñ]+\b', content.lower())
+    
+    if len(words) < window_size:
+        return True
+    
+    # Heuristic 1: Sliding window with low unique word ratio
+    # This catches sequences where the same or similar words repeat
+    repetitive_windows = 0
+    for i in range(len(words) - window_size + 1):
+        window = words[i:i + window_size]
+        unique_ratio = len(set(window)) / len(window)
+        if unique_ratio < max_unique_ratio:
+            repetitive_windows += 1
+            if repetitive_windows >= min_window_matches:
+                return False
+    
+    # Heuristic 2: Suffix pattern detection
+    # Catches sequences like "precisamente calculadamente programaticamente"
+    common_suffixes = ['mente', 'ando', 'endo', 'indo', 'ado', 'ido', 'ada', 'ida',
+                       'ção', 'ções', 'dade', 'dades', 'ável', 'ível', 'oso', 'osa']
+    
+    for suffix in common_suffixes:
+        consecutive_suffix_count = 0
+        max_consecutive = 0
+        for word in words:
+            if word.endswith(suffix) and len(word) > len(suffix) + 2:
+                consecutive_suffix_count += 1
+                max_consecutive = max(max_consecutive, consecutive_suffix_count)
+            else:
+                consecutive_suffix_count = 0
+        
+        # If we find 8+ consecutive words with the same suffix, it's likely a loop
+        if max_consecutive >= 8:
+            return False
+    
+    # Heuristic 3: N-gram repetition detection
+    # Catches exact phrase repetitions
+    if len(words) >= 10:
+        for n in [3, 4, 5]:  # Check trigrams, 4-grams, and 5-grams
+            ngrams = [tuple(words[i:i+n]) for i in range(len(words) - n + 1)]
+            ngram_counts = {}
+            for ng in ngrams:
+                ngram_counts[ng] = ngram_counts.get(ng, 0) + 1
+            
+            # If any n-gram appears more than 5 times, likely a loop
+            max_count = max(ngram_counts.values()) if ngram_counts else 0
+            if max_count >= 5:
+                return False
+    
+    # Heuristic 4: Long sequences of single-word repetition
+    # Catches "word word word word word..."
+    for i in range(len(words) - min_repeated_words):
+        if len(set(words[i:i + min_repeated_words])) == 1:
+            return False
     
     return True
 
@@ -355,7 +455,31 @@ def filter_minimum_tokens(example, min_tokens):
     except (KeyError, TypeError):
         return False
 
-def remove_system_messages(example):
+
+def filter_quality_score(example, score_column, min_score):
+    """
+    Filter out samples below the minimum quality score threshold.
+    
+    Used to filter based on quality annotation columns like 'instruct_score',
+    'educational_score', or similar metrics from quality classifiers.
+    
+    Args:
+        example: A dataset sample with a quality score field.
+        score_column: Name of the column containing the quality score.
+        min_score: Minimum score required to keep the sample.
+    
+    Returns:
+        bool: True if sample meets the threshold, False otherwise.
+    """
+    try:
+        score = example.get(score_column, None)
+        if score is None:
+            return False
+        return float(score) >= min_score
+    except (KeyError, TypeError, ValueError):
+        return False
+
+def remove_system_messages(example, messages_column="messages"):
     """
     Remove all system messages from the sample's conversation.
     
@@ -364,13 +488,14 @@ def remove_system_messages(example):
     they are corrupted.
     
     Args:
-        example: A dataset sample containing a 'messages' field.
+        example: A dataset sample containing a messages field.
+        messages_column: The name of the column containing messages.
     
     Returns:
         dict: A copy of the example with system messages removed.
     """
     try:
-        messages = example.get("messages", [])
+        messages = example.get(messages_column, [])
         if not messages:
             return example
         
@@ -382,13 +507,13 @@ def remove_system_messages(example):
         
         # Create a copy of the example with filtered messages
         new_example = dict(example)
-        new_example["messages"] = filtered_messages
+        new_example[messages_column] = filtered_messages
         return new_example
     except (KeyError, TypeError, AttributeError):
         return example
 
 
-def strip_message_content(example):
+def strip_message_content(example, messages_column="messages"):
     """
     Strip leading and trailing whitespace from all message content.
     
@@ -396,13 +521,14 @@ def strip_message_content(example):
     This ensures consistent handling of messages regardless of source formatting.
     
     Args:
-        example: A dataset sample containing a 'messages' field.
+        example: A dataset sample containing a messages field.
+        messages_column: The name of the column containing messages.
     
     Returns:
         dict: A copy of the example with whitespace-stripped message content.
     """
     try:
-        messages = example.get("messages", [])
+        messages = example.get(messages_column, [])
         if not messages:
             return example
         
@@ -416,13 +542,13 @@ def strip_message_content(example):
         
         # Create a copy of the example with stripped messages
         new_example = dict(example)
-        new_example["messages"] = stripped_messages
+        new_example[messages_column] = stripped_messages
         return new_example
     except (KeyError, TypeError, AttributeError):
         return example
 
 
-def filter_incomplete_sentences(example):
+def filter_incomplete_sentences(example, messages_column="messages"):
     """
     Filter out samples where the final message doesn't end with proper punctuation.
     
@@ -431,13 +557,14 @@ def filter_incomplete_sentences(example):
     The $ is included to support LaTeX math expressions.
     
     Args:
-        example: A dataset sample containing a 'messages' field.
+        example: A dataset sample containing a messages field.
+        messages_column: The name of the column containing messages.
     
     Returns:
         bool: True if the final message ends properly, False otherwise.
     """
     try:
-        messages = example["messages"]
+        messages = example[messages_column]
         if not messages or len(messages) == 0:
             return False
         
@@ -622,65 +749,115 @@ def main(args):
     assert args.input_type in ["jsonl", "parquet"], "Input type must be either 'jsonl' or 'parquet'."
     assert args.output_type in ["jsonl", "parquet"], "Output type must be either 'jsonl' or 'parquet'."
     
+    # Get the messages column name
+    messages_column = args.messages_column
+    
     # Load dataset
     print(f"[INFO] Loading dataset from {args.input_dir}")
     dataset, num_input_files = load_dataset(args.input_dir, args.input_type, args.cache_dir)
     print(f"[INFO] Loaded dataset with {len(dataset):,} examples")
-    print(f"[INFO] Columns: {dataset.column_names}\n")
+    print(f"[INFO] Columns: {dataset.column_names}")
+    print(f"[INFO] Messages column: {messages_column}\n")
     
     initial_count = len(dataset)
     
     # Default preprocessing: Strip whitespace from all message content
-    if "messages" in dataset.column_names:
+    if messages_column in dataset.column_names:
         print(f"[INFO] Stripping whitespace from message content...")
-        dataset = dataset.map(strip_message_content, num_proc=args.num_proc)
+        dataset = dataset.map(
+            lambda x: strip_message_content(x, messages_column), 
+            num_proc=args.num_proc
+        )
         print(f"[INFO] Whitespace stripped from {len(dataset):,} samples\n")
     
     # Preprocessing: Remove system messages if enabled
-    if args.remove_system_messages and "messages" in dataset.column_names:
+    if args.remove_system_messages and messages_column in dataset.column_names:
         print(f"[INFO] Removing system messages from all samples...")
-        dataset = dataset.map(remove_system_messages, num_proc=args.num_proc)
+        dataset = dataset.map(
+            lambda x: remove_system_messages(x, messages_column), 
+            num_proc=args.num_proc
+        )
         print(f"[INFO] System messages removed from {len(dataset):,} samples\n")
     
     # Apply filters
-    if args.filter_incomplete_sentences and "messages" in dataset.column_names:
+    if args.filter_incomplete_sentences and messages_column in dataset.column_names:
         print(f"[INFO] Filtering samples with incomplete sentences...")
-        dataset = dataset.filter(filter_incomplete_sentences, num_proc=args.num_proc)
+        dataset = dataset.filter(
+            lambda x: filter_incomplete_sentences(x, messages_column), 
+            num_proc=args.num_proc
+        )
         filtered_incomplete = initial_count - len(dataset)
         print(f"[INFO] Removed {filtered_incomplete:,} samples with incomplete sentences")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
     
-    if args.filter_malformed_code_blocks and "messages" in dataset.column_names:
+    if args.filter_malformed_code_blocks and messages_column in dataset.column_names:
         print(f"[INFO] Filtering samples with malformed code blocks...")
         before_filter = len(dataset)
-        dataset = dataset.filter(filter_malformed_code_blocks, num_proc=args.num_proc)
+        dataset = dataset.filter(
+            lambda x: filter_malformed_code_blocks(x, messages_column), 
+            num_proc=args.num_proc
+        )
         filtered_count = before_filter - len(dataset)
         print(f"[INFO] Removed {filtered_count:,} samples with malformed code blocks")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
     
-    if args.filter_corrupted_code and "messages" in dataset.column_names:
+    if args.filter_corrupted_code and messages_column in dataset.column_names:
         print(f"[INFO] Filtering samples with corrupted/mistranslated code content...")
         before_filter = len(dataset)
-        dataset = dataset.filter(filter_corrupted_code_content, num_proc=args.num_proc)
+        dataset = dataset.filter(
+            lambda x: filter_corrupted_code_content(x, messages_column), 
+            num_proc=args.num_proc
+        )
         filtered_count = before_filter - len(dataset)
         print(f"[INFO] Removed {filtered_count:,} samples with corrupted code content")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
     
-    if args.filter_undecoded_sequences:
+    if args.filter_undecoded_sequences and messages_column in dataset.column_names:
         print(f"[INFO] Filtering samples with undecoded Unicode escape sequences...")
         before_filter = len(dataset)
-        dataset = dataset.filter(filter_undecoded_sequences, num_proc=args.num_proc)
+        dataset = dataset.filter(
+            lambda x: filter_undecoded_sequences(x, messages_column), 
+            num_proc=args.num_proc
+        )
         filtered_count = before_filter - len(dataset)
         print(f"[INFO] Removed {filtered_count:,} samples with undecoded sequences")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
     
-    if args.filter_invalid_markers:
+    if args.filter_invalid_markers and messages_column in dataset.column_names:
         print(f"[INFO] Filtering samples with invalid structural markers (#### followed by number)...")
         before_filter = len(dataset)
-        dataset = dataset.filter(filter_invalid_structural_markers, num_proc=args.num_proc)
+        dataset = dataset.filter(
+            lambda x: filter_invalid_structural_markers(x, messages_column), 
+            num_proc=args.num_proc
+        )
         filtered_count = before_filter - len(dataset)
         print(f"[INFO] Removed {filtered_count:,} samples with invalid structural markers")
         print(f"[INFO] Remaining samples: {len(dataset):,}\n")
+    
+    if args.filter_repetition_loops and messages_column in dataset.column_names:
+        print(f"[INFO] Filtering samples with word repetition loops...")
+        before_filter = len(dataset)
+        dataset = dataset.filter(
+            lambda x: filter_repetition_loops(x, messages_column), 
+            num_proc=args.num_proc
+        )
+        filtered_count = before_filter - len(dataset)
+        print(f"[INFO] Removed {filtered_count:,} samples with repetition loops")
+        print(f"[INFO] Remaining samples: {len(dataset):,}\n")
+    
+    if args.min_quality_score is not None and args.quality_score_column:
+        if args.quality_score_column in dataset.column_names:
+            print(f"[INFO] Filtering samples with {args.quality_score_column} < {args.min_quality_score}...")
+            before_filter = len(dataset)
+            dataset = dataset.filter(
+                lambda x: filter_quality_score(x, args.quality_score_column, args.min_quality_score), 
+                num_proc=args.num_proc
+            )
+            filtered_count = before_filter - len(dataset)
+            print(f"[INFO] Removed {filtered_count:,} samples below quality score threshold")
+            print(f"[INFO] Remaining samples: {len(dataset):,}\n")
+        else:
+            print(f"[WARNING] Quality score column '{args.quality_score_column}' not found in dataset. Skipping filter.")
     
     if args.min_token_count is not None and "token_count" in dataset.column_names:
         print(f"[INFO] Filtering samples with token_count < {args.min_token_count:,}...")
@@ -710,7 +887,7 @@ def main(args):
         print(f"[INFO] Total tokens in filtered dataset: {total_tokens:,}")
     
     # Determine number of chunks based on total tokens after filtering
-    if total_tokens is not None and args.max_tokens_per_chunk is not None:
+    if total_tokens is not None:
         num_chunks = max(1, (total_tokens + args.max_tokens_per_chunk - 1) // args.max_tokens_per_chunk)
         print(f"[INFO] Calculating chunks based on token count (~{args.max_tokens_per_chunk:,} tokens per chunk, {num_chunks} chunk(s))")
     else:
@@ -764,6 +941,18 @@ if __name__ == "__main__":
                         help="Filter out samples containing invalid structural markers (lines starting with #### followed by a number)")
     parser.add_argument("--remove_system_messages", action="store_true",
                         help="Remove all system messages from samples before processing (disabled by default)")
+    parser.add_argument("--filter_repetition_loops", action="store_true",
+                        help="Filter out samples where the model gets stuck in word repetition loops")
+    
+    # Quality score filtering
+    parser.add_argument("--quality_score_column", type=str, default=None,
+                        help="Name of the column containing quality scores (e.g., 'instruct_score', 'educational_score')")
+    parser.add_argument("--min_quality_score", type=float, default=None,
+                        help="Minimum quality score threshold; samples below this will be filtered out")
+    
+    # Messages column configuration
+    parser.add_argument("--messages_column", type=str, default="messages",
+                        help="Name of the column containing the messages/conversation data (default: 'messages')")
     
     # Number of processes to use for parallel filtering
     parser.add_argument("--num_proc", type=int, default=4, help="Number of processes to use for filtering (default: 4)")

--- a/data/filters/sft_filters.py
+++ b/data/filters/sft_filters.py
@@ -184,6 +184,18 @@ MISTRANSLATED_CODE_INDICATORS = re.compile(
     re.IGNORECASE
 )
 
+# Portuguese stopwords to exclude from uniqueness calculations
+# These common words naturally repeat in normal text and shouldn't trigger the filter
+PORTUGUESE_STOPWORDS = {
+    'a', 'o', 'e', 'de', 'da', 'do', 'das', 'dos', 'em', 'na', 'no', 'nas', 'nos',
+    'um', 'uma', 'uns', 'umas', 'para', 'por', 'com', 'como', 'que', 'se', 'ou',
+    'mais', 'mas', 'ao', 'aos', 'à', 'às', 'ser', 'ter', 'estar', 'foi', 'são',
+    'é', 'esse', 'essa', 'este', 'esta', 'isso', 'isto', 'aquele', 'aquela',
+    'seu', 'sua', 'seus', 'suas', 'ele', 'ela', 'eles', 'elas', 'nós', 'você',
+    'entre', 'sobre', 'até', 'já', 'também', 'muito', 'bem', 'só', 'ainda',
+    'quando', 'onde', 'qual', 'quais', 'quem', 'porque', 'pode', 'podem',
+    'deve', 'devem', 'há', 'sem', 'pela', 'pelo', 'pelas', 'pelos', 'após',
+}
 
 def get_all_content(example, messages_column="messages"):
     """
@@ -349,8 +361,9 @@ def filter_invalid_structural_markers(example, messages_column="messages"):
 
 
 def filter_repetition_loops(example, messages_column="messages", 
-                            min_repeated_words=5, max_unique_ratio=0.3,
-                            window_size=50, min_window_matches=3):
+                            min_repeated_words=8, max_unique_ratio=0.15,
+                            window_size=30, min_window_matches=5,
+                            min_consecutive_suffix=12, min_ngram_repeats=10):
     """
     Filter out samples where the model gets stuck in word repetition loops.
     
@@ -361,17 +374,23 @@ def filter_repetition_loops(example, messages_column="messages",
     - "consolidadas solidificadas fortalecidas reforçadas intensificadas ampliadas"
     
     The detection uses multiple heuristics:
-    1. Sliding window analysis: Checks for windows with low unique word ratio
+    1. Sliding window analysis: Checks for windows with very low unique content word ratio
     2. Suffix pattern detection: Identifies long sequences of words with same suffix
-    3. N-gram repetition: Detects repeated word sequences
+    3. N-gram repetition: Detects repeated word sequences (scaled by document length)
+    4. Single-word repetition: Detects "word word word word..."
+    
+    Note: This filter excludes common stopwords from uniqueness calculations to avoid
+    false positives on normal prose that naturally repeats function words.
     
     Args:
         example: A dataset sample to validate.
         messages_column: The name of the column containing messages.
-        min_repeated_words: Minimum words in a sequence to check for repetition.
-        max_unique_ratio: Maximum ratio of unique words in a window to be flagged.
+        min_repeated_words: Minimum consecutive identical words to flag.
+        max_unique_ratio: Maximum ratio of unique content words in a window to be flagged.
         window_size: Size of sliding window for analysis.
         min_window_matches: Minimum windows that must match to filter the sample.
+        min_consecutive_suffix: Minimum consecutive words with same suffix to flag.
+        min_ngram_repeats: Minimum n-gram repetitions to flag.
     
     Returns:
         bool: True if sample is valid (should be kept), False if contains repetition loops.
@@ -386,49 +405,68 @@ def filter_repetition_loops(example, messages_column="messages",
     if len(words) < window_size:
         return True
     
-    # Heuristic 1: Sliding window with low unique word ratio
-    # This catches sequences where the same or similar words repeat
-    repetitive_windows = 0
-    for i in range(len(words) - window_size + 1):
-        window = words[i:i + window_size]
-        unique_ratio = len(set(window)) / len(window)
-        if unique_ratio < max_unique_ratio:
-            repetitive_windows += 1
-            if repetitive_windows >= min_window_matches:
-                return False
+    # Filter out stopwords for content analysis (but keep original for suffix/ngram checks)
+    content_words = [w for w in words if w not in PORTUGUESE_STOPWORDS and len(w) > 2]
     
-    # Heuristic 2: Suffix pattern detection
+    # Heuristic 1: Sliding window with low unique content word ratio
+    # This catches sequences where the same or similar content words repeat
+    # Only applies to content words (excluding stopwords)
+    if len(content_words) >= window_size:
+        repetitive_windows = 0
+        for i in range(len(content_words) - window_size + 1):
+            window = content_words[i:i + window_size]
+            unique_ratio = len(set(window)) / len(window)
+            if unique_ratio < max_unique_ratio:
+                repetitive_windows += 1
+                if repetitive_windows >= min_window_matches:
+                    return False
+    
+    # Heuristic 2: Suffix pattern detection (stricter)
     # Catches sequences like "precisamente calculadamente programaticamente"
-    common_suffixes = ['mente', 'ando', 'endo', 'indo', 'ado', 'ido', 'ada', 'ida',
-                       'ção', 'ções', 'dade', 'dades', 'ável', 'ível', 'oso', 'osa']
+    # Only check for the most problematic suffixes that indicate degenerate loops
+    degenerate_suffixes = ['mente', 'ando', 'endo', 'indo']  # Most indicative of loops
     
-    for suffix in common_suffixes:
+    for suffix in degenerate_suffixes:
         consecutive_suffix_count = 0
         max_consecutive = 0
         for word in words:
-            if word.endswith(suffix) and len(word) > len(suffix) + 2:
+            # Word must be substantial (not just the suffix)
+            if word.endswith(suffix) and len(word) > len(suffix) + 3:
                 consecutive_suffix_count += 1
                 max_consecutive = max(max_consecutive, consecutive_suffix_count)
             else:
                 consecutive_suffix_count = 0
         
-        # If we find 8+ consecutive words with the same suffix, it's likely a loop
-        if max_consecutive >= 8:
+        # High threshold: 12+ consecutive words with the same suffix is truly degenerate
+        if max_consecutive >= min_consecutive_suffix:
             return False
     
-    # Heuristic 3: N-gram repetition detection
-    # Catches exact phrase repetitions
-    if len(words) >= 10:
-        for n in [3, 4, 5]:  # Check trigrams, 4-grams, and 5-grams
-            ngrams = [tuple(words[i:i+n]) for i in range(len(words) - n + 1)]
-            ngram_counts = {}
-            for ng in ngrams:
-                ngram_counts[ng] = ngram_counts.get(ng, 0) + 1
+    # Heuristic 3: N-gram repetition detection (scaled by document length)
+    # Catches exact phrase repetitions, but with thresholds proportional to doc length
+    if len(words) >= 50:
+        # Scale threshold by document length - longer docs naturally have more repetition
+        # For a 500-word doc, threshold is ~10; for 1000-word doc, ~14
+        length_factor = max(1, len(words) / 500)
+        dynamic_threshold = int(min_ngram_repeats * (0.7 + 0.3 * length_factor))
+        
+        for n in [4, 5, 6]:  # Check 4-grams, 5-grams, and 6-grams (not trigrams - too common)
+            # Exclude n-grams that are mostly stopwords
+            ngrams = []
+            for i in range(len(words) - n + 1):
+                ng = tuple(words[i:i+n])
+                # Only count if at least half of the words are content words
+                content_count = sum(1 for w in ng if w not in PORTUGUESE_STOPWORDS)
+                if content_count >= n // 2:
+                    ngrams.append(ng)
             
-            # If any n-gram appears more than 5 times, likely a loop
-            max_count = max(ngram_counts.values()) if ngram_counts else 0
-            if max_count >= 5:
-                return False
+            if ngrams:
+                ngram_counts = {}
+                for ng in ngrams:
+                    ngram_counts[ng] = ngram_counts.get(ng, 0) + 1
+                
+                max_count = max(ngram_counts.values())
+                if max_count >= dynamic_threshold:
+                    return False
     
     # Heuristic 4: Long sequences of single-word repetition
     # Catches "word word word word word..."

--- a/data/filters/sft_filters.sh
+++ b/data/filters/sft_filters.sh
@@ -52,20 +52,23 @@ echo "# Python executable: $(which python3)" >> "$out"
 #############################################
 # Main Job Execution
 #############################################
-python3 $workdir/portuguese/gigaverbo-v2-sft/filter.py \
+python3 $workdir/scripts/filter.py \
     --input_dir "$workdir/portuguese/gigaverbo-v2-sft/general" \
     --input_type jsonl \
     --output_dir "$workdir/portuguese/gigaverbo-v2-sft/general_filtered" \
     --output_type jsonl \
     --cache_dir "$HF_DATASETS_CACHE" \
-    --min_token_count 500 \
-    --max_token_count 2048 \
+    --messages_column "messages" \
+    --min_token_count 120 \
+    --max_token_count 1000 \
+    --filter_invalid_markers \
+    --filter_repetition_loops \
+    --filter_undecoded_sequences \
     --filter_incomplete_sentences \
     --filter_malformed_code_blocks \
     --filter_corrupted_code \
-    --filter_undecoded_sequences \
-    --filter_invalid_markers \
-    --remove_system_messages \
+    --quality_score_column "instruct_score" \
+    --min_quality_score 4.5 \
     --num_proc 32 1>>"$out" 2>>"$err"
 
 #############################################

--- a/data/filters/train_classifier.py
+++ b/data/filters/train_classifier.py
@@ -16,7 +16,9 @@ Output:
 
 Usage:
     # Train edu-score classifier
-    python train_classifier.py --dataset_path scored_data.jsonl \
+    python train_classifier.py --train_dataset_dir scored_data.jsonl \
+        --dataset_type jsonl \
+        --shuffle_dataset \
         --model_name microsoft/deberta-v3-base \
         --text_column text --target_column score --id_label Edu-Score \
         --checkpoint_dir checkpoints/ --max_length 512 \
@@ -24,7 +26,9 @@ Usage:
         --learning_rate 3e-4 --bf16
     
     # Train with frozen layers (faster)
-    python train_classifier.py --dataset_path data.jsonl \
+    python train_classifier.py --train_dataset_dir data.jsonl \
+        --dataset_type jsonl \
+        --shuffle_dataset \
         --model_name Qwen/Qwen2-1.5B --freeze \
         --checkpoint_dir ckpt/ --gradient_checkpointing \
         --hub_token TOKEN --hub_model_id username/my-classifier
@@ -82,40 +86,48 @@ def compute_metrics(eval_pred):
 
 def main(args):
 
-    if os.path.exists(args.dataset_path):
-        
-        # Try to load the dataset from the specified path (JSONL)
-        files = glob.glob(os.path.join(args.dataset_path, "*.jsonl"))
-        file_type = "json"
-        if not files:
-            # If no JSONL files found, try to load Parquet files
-            file_type = "parquet"
-            files = glob.glob(os.path.join(args.dataset_path, "*.parquet"))
+    # Initialize the partial state for distributed training
+    state = accelerate.PartialState()
+    # print the state of every process
+    master_process = int(state.process_index) == 0
+    if master_process:
+        print(f"{state}")
 
-        if files:
-            dataset = datasets.load_dataset(
-                file_type,
-                data_files=files,
-                cache_dir=args.cache_dir,
-                num_proc=len(files),
-                split="train",
-            )
-        else:
-            raise ValueError(f"No JSONL or Parquet files found in {args.dataset_path}")
-    else:
-        try:
-            # We assume the dataset is a Hugging Face dataset.
-            dataset = datasets.load_dataset(
-                args.dataset_path, 
-                split=args.split, 
-                cache_dir=args.cache_dir, 
-                num_proc=args.num_proc
-            )
-        except:
-            # If it also fails, we give up and raise an error.
-            raise ValueError(f"Dataset path {args.dataset_path} is not a directory or a Hugging Face dataset")
+    # Load our training dataset.
+    # We expect the dataset to be in a specific format: jsonl or parquet.
+    assert args.dataset_type in ["jsonl", "parquet"], f"Dataset type must be either 'jsonl' or 'parquet', got {args.dataset_type}."
 
-    # Given that the scores we generated in `filter.py` are in the range [1, 5], 
+    train_dataset_files = []
+    train_dirs = args.train_dataset_dir
+    if isinstance(train_dirs, str):
+        train_dirs = [train_dirs]
+
+    # Below, we loop over all training directories and collect the dataset files that
+    # have the correct file extension.
+    for train_dir in train_dirs:
+        if os.path.isfile(train_dir) and train_dir.endswith(f".{args.dataset_type}"):
+            train_dataset_files.append(train_dir)
+        elif os.path.isdir(train_dir):
+            train_dataset_files += glob.glob(f"{train_dir}/*.{args.dataset_type}")
+
+    # Ensure all processes have the same file list (synchronize before loading)
+    train_dataset_files = sorted(train_dataset_files)
+    state.wait_for_everyone()
+
+    # Load the datasets from disk
+    # [datasets.load_dataset](https://huggingface.co/docs/datasets/main/en/package_reference/loading_methods#datasets.load_dataset)
+    dataset = datasets.load_dataset(
+        "json" if args.dataset_type == "jsonl" else args.dataset_type,
+        data_files=train_dataset_files,
+        split='train',
+        num_proc=min(len(train_dataset_files), args.num_proc),
+        cache_dir=args.cache_dir,
+    )
+
+    if args.shuffle_dataset:
+        dataset = dataset.shuffle(seed=args.seed)
+
+    # Given that the scores we generated in `llm_filter.py` are in the range [1, 5], 
     # we need to convert them to the range [0, 4] for training.
     dataset = dataset.map(
         lambda x: {args.target_column: np.clip(int(x[args.target_column])-1, 0, 4)},
@@ -150,7 +162,7 @@ def main(args):
         "trust_remote_code": True,
         "use_cache": True if not args.gradient_checkpointing else False,
         "torch_dtype": torch.bfloat16 if args.bf16 else torch.float32,
-        "device_map":{'':accelerate.PartialState().process_index},
+        "device_map":{'':state.process_index},
     }
     
     # Add classifier_dropout for non-DeBERTa models (will be ignored by DeBERTa)
@@ -200,16 +212,31 @@ def main(args):
     if args.text_column not in dataset['train'].column_names:
         raise ValueError(f"Text column '{args.text_column}' not found in the dataset. Available columns: {dataset['train'].column_names}")
     
-    def preprocess(examples):
-        batch = tokenizer(examples[args.text_column], truncation=True)
-        batch["labels"] = np.float32(examples[args.target_column])
-        return batch
+    # Only main process runs the preprocessing and mapping
+    if master_process:
+        def preprocess(examples):
+            batch = tokenizer(examples[args.text_column], truncation=True)
+            batch["labels"] = np.float32(examples[args.target_column])
+            return batch
 
-    dataset = dataset.map(
-        preprocess, 
-        batched=True,
-        num_proc=args.num_proc,
-    )
+        dataset = dataset.map(
+            preprocess, 
+            batched=True,
+            num_proc=args.num_proc,
+            load_from_cache_file=True,
+            desc="Tokenizing dataset",
+        )
+    # Wait for main process to finish preprocessing
+    state.wait_for_everyone()
+
+    # Non-main processes reload from cache
+    if not master_process:
+        dataset = dataset.map(
+            preprocess,
+            num_proc=args.num_proc,
+            load_from_cache_file=True,
+            desc=f"Loading preprocessed dataset on process {state.process_index}",
+        )
 
     # Create a simple data collator that pads the inputs to the maximum length in the batch
     # [DataCollatorWithPadding](https://huggingface.co/docs/transformers/main_classes/data_collator#transformers.DataCollatorWithPadding)
@@ -311,21 +338,58 @@ def main(args):
         compute_metrics=compute_metrics,
     )
 
-    trainer.train(resume_from_checkpoint=args.resume_from_checkpoint)
-    trainer.save_model(os.path.join(args.checkpoint_dir, "final"))
+    # Make sure every process is synced before training
+    state.wait_for_everyone()
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+    
+    if args.resume_from_checkpoint:
+
+        # We expect the `resume_from_checkpoint` argument to be the path to a directory of checkpoints,
+        # the logic below will find the latest checkpoint in that directory.
+        checkpoint_path = args.resume_from_checkpoint
+
+        try:
+            # We try to find the latest checkpoint in the directory.
+            checkpoint_dirs = os.listdir(checkpoint_path)
+            checkpoint_dirs = [dir for dir in checkpoint_dirs if dir.startswith(f"checkpoint-")] # Checkpoints are intended to be named like "checkpoint-"
+            checkpoint_path = os.path.join(checkpoint_path, sorted(checkpoint_dirs, key=lambda x: int(x.split("-")[-1].split(".")[0]))[-1])
+        except:
+            # If the checkpoint directory does not contain any checkpoints, we will assume
+            # that `resume_from_checkpoint` is already set to the latest checkpoint.
+            pass
+        if master_process:
+            print(f"Resuming training from checkpoint: {checkpoint_path}")
+
+    # Start the training
+    try:
+        trainer.train(resume_from_checkpoint=checkpoint_path if args.resume_from_checkpoint else None)
+    except Exception as e:
+        save_path = os.path.join(args.checkpoint_dir, "last")
+        trainer.save_model(save_path)
+        if master_process:
+            print(f"Training failed with error: {e}")
+            print(f"Model saved to 'last' checkpoint at {save_path}")
+
     try:
         trainer.evaluate()
     except Exception as e:
-        print(f"Evaluation failed with error: {e}")
-        print("Skipping final evaluation...")
+        if master_process:
+            print(f"Evaluation failed with error: {e}")
+            print("Skipping final evaluation...")
 
+    # Save the final model
+    trainer.save_model(os.path.join(args.checkpoint_dir, "final"))
+    # Done!
+    
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     # Core dataset/model args
-    parser.add_argument("--dataset_path", type=str, required=True)
-    parser.add_argument("--cache_dir", type=str, default=None)
-    parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--dataset_type", choices=["jsonl", "parquet"], default="parquet", help="Type of the dataset files. Can be either 'jsonl' or 'parquet'.")
+    parser.add_argument("--train_dataset_dir", type=str, nargs="+", required=True, help="Path(s) to the training dataset directory or file. Can be a single directory/file or a list of directories/files.")
+    parser.add_argument("--shuffle_dataset", action="store_true", help="If set, shuffle the dataset files before loading.")
+    parser.add_argument("--cache_dir", type=str, default=None, help="Path to a directory to use for caching the datasets and models.")
     parser.add_argument("--num_proc", type=int, default=16)
     parser.add_argument("--target_column", type=str, default="score")
     parser.add_argument("--text_column", type=str, default="text")

--- a/data/filters/train_classifier.py
+++ b/data/filters/train_classifier.py
@@ -277,7 +277,7 @@ def main(args):
         weight_decay=args.weight_decay,
         max_grad_norm=args.max_grad_norm,
         lr_scheduler_type=args.lr_scheduler_type,
-        warmup_steps=args.warmup_steps,
+        warmup_ratio=args.warmup_ratio,
         num_train_epochs=args.num_train_epochs,
         seed=args.seed,
         per_device_train_batch_size=args.per_device_train_batch_size,
@@ -350,7 +350,7 @@ if __name__ == "__main__":
     parser.add_argument("--adam_epsilon", type=float, default=1e-8)
     parser.add_argument("--max_grad_norm", type=float, default=1.0)
     parser.add_argument("--lr_scheduler_type", type=str, default="linear", help="Type of learning rate scheduler to use. Options: 'linear', 'cosine', and all the other types listed [here](https://huggingface.co/docs/transformers/main/en/main_classes/optimizer_schedules#transformers.SchedulerType).")
-    parser.add_argument("--warmup_steps", type=int, default=0)
+    parser.add_argument("--warmup_ratio", type=float, default=0.0)
     parser.add_argument("--num_train_epochs", type=int, default=20)
     parser.add_argument("--save_total_limit", type=int, default=5)
     parser.add_argument("--eval_on_start", action="store_true")

--- a/data/filters/train_classifier.py
+++ b/data/filters/train_classifier.py
@@ -366,7 +366,7 @@ if __name__ == "__main__":
     # Hub / reporting
     parser.add_argument("--hub_token", type=str, default=None)
     parser.add_argument("--hub_model_id", type=str, default=None)
-    parser.add_argument("--report_to", type=str, nargs="+", default=["wandb", "codecarbon"])
+    parser.add_argument("--report_to", type=str, nargs="+", default=None , help="The list of integrations to report the results and logs to. Supported platforms are 'tensorboard', 'wandb', 'comet_ml', 'mlflow', 'clearml', 'wandb' etc. See [here](https://huggingface.co/docs/transformers/main/en/main_classes/trainer#transformers.TrainingArguments.report_to) for more details.")
     parser.add_argument("--wandb_project", type=str, default="Polyglot")
 
     args = parser.parse_args()

--- a/data/filters/train_classifier.sh
+++ b/data/filters/train_classifier.sh
@@ -76,7 +76,9 @@ export LAUNCHER="accelerate launch --config_file $workdir/.ddp_config.yaml"
 
 export PYTHON_FILE="$workdir/train_classifier.py"
 
-export ARGS="--dataset_path ./portuguese/portuguese-instruct-quality-qwen-annotations/data \
+export ARGS="--train_dataset_dir ./portuguese/portuguese-instruct-quality-qwen-annotations/data \
+--dataset_type jsonl \
+--shuffle_dataset \
 --cache_dir $HF_DATASETS_CACHE \
 --num_proc $SLURM_CPUS_PER_TASK \
 --model_name Qwen/Qwen3-4B \

--- a/data/filters/train_classifier.sh
+++ b/data/filters/train_classifier.sh
@@ -91,7 +91,7 @@ export ARGS="--dataset_path ./portuguese/portuguese-instruct-quality-qwen-annota
 --learning_rate 0.00005 \
 --weight_decay 0.1 \
 --lr_scheduler_type cosine \
---warmup_steps 100 \
+--warmup_ratio 0.1 \
 --num_train_epochs 2 \
 --attn_implementation flash_attention_2 \
 --per_device_train_batch_size 4 \
@@ -120,4 +120,4 @@ else
     echo "# [${SLURM_JOB_ID}] Skipping cache cleanup (CLEAN_CACHE=$CLEAN_CACHE)" >> "$out"
 fi
 
-echo "# [${SLURM_JOB_ID}] Job finished at: $(date)" >> "$out
+echo "# [${SLURM_JOB_ID}] Job finished at: $(date)" >> "$out"

--- a/dpo/dpo_trainer.py
+++ b/dpo/dpo_trainer.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
     # Hub / reporting
     parser.add_argument("--hub_token", type=str, default=None)
     parser.add_argument("--hub_model_id", type=str, default=None)
-    parser.add_argument("--report_to", type=str, nargs="+", default=["wandb", "codecarbon"])
+    parser.add_argument("--report_to", type=str, nargs="+", default=None , help="The list of integrations to report the results and logs to. Supported platforms are 'tensorboard', 'wandb', 'comet_ml', 'mlflow', 'clearml', 'wandb' etc. See [here](https://huggingface.co/docs/transformers/main/en/main_classes/trainer#transformers.TrainingArguments.report_to) for more details.")
     parser.add_argument("--wandb_project", type=str, default="Polyglot")
     # Experimental / other
     parser.add_argument("--use_liger_kernel", action="store_true", help="Use the Liger kernel for training (experimental).")

--- a/dpo/dpo_trainer.py
+++ b/dpo/dpo_trainer.py
@@ -104,14 +104,14 @@ def main(args):
 
     # Convert the dataset so that the prompt is explicitly defined.
     # Why? -> https://huggingface.co/docs/trl/main/en/dpo_trainer#expected-dataset-type
-    #if "prompt" not in dataset.column_names:
-    #   if master_process:
-    #       dataset = dataset.map(trl.extract_prompt, num_proc=args.num_proc, desc="Extracting prompt from the data")
-    #   state.wait_for_everyone()
-    #   if not master_process:
-    #       dataset = dataset.map(trl.extract_prompt, num_proc=args.num_proc, desc="Extracting prompt from the data")        
-    #
-    # Split the dataset into train and test sets if a test size is specified
+    if "prompt" not in dataset.column_names:
+        if master_process:
+            dataset = dataset.map(trl.extract_prompt, num_proc=args.num_proc, desc="Extracting prompt from the data", load_from_cache_file=False)
+
+        state.wait_for_everyone()
+        if not master_process:
+            dataset = dataset.map(trl.extract_prompt, num_proc=args.num_proc, desc="Extracting prompt from the data", load_from_cache_file=True)
+
     if args.test_size is not None:
         dataset = dataset.train_test_split(
             test_size=args.test_size,

--- a/dpo/dpo_trainer.py
+++ b/dpo/dpo_trainer.py
@@ -228,7 +228,7 @@ def main(args):
         adam_epsilon=args.adam_epsilon,
         max_grad_norm=args.max_grad_norm,
         lr_scheduler_type=args.lr_scheduler_type,
-        warmup_steps=args.warmup_steps,
+        warmup_ratio=args.warmup_ratio,
         num_train_epochs=args.num_train_epochs,
         max_steps=-1 if args.max_steps is None else args.max_steps,
         per_device_train_batch_size=args.per_device_train_batch_size,
@@ -318,7 +318,7 @@ if __name__ == "__main__":
     parser.add_argument("--adam_epsilon", type=float, default=1e-8)
     parser.add_argument("--max_grad_norm", type=float, default=1.0)
     parser.add_argument("--lr_scheduler_type", type=str, default="linear", help="Type of learning rate scheduler to use.")
-    parser.add_argument("--warmup_steps", type=int, default=0)
+    parser.add_argument("--warmup_ratio", type=float, default=0.0)
     parser.add_argument("--num_train_epochs", type=int, default=1)
     parser.add_argument("--max_steps", type=int, default=None, help="Total number of training steps to perform. If set, overrides num_train_epochs.")
     # Precision / performance

--- a/dpo/dpo_trainer.py
+++ b/dpo/dpo_trainer.py
@@ -260,15 +260,34 @@ def main(args):
     state.wait_for_everyone()
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
+    
+    if args.resume_from_checkpoint:
+
+        # We expect the `resume_from_checkpoint` argument to be the path to a directory of checkpoints,
+        # the logic below will find the latest checkpoint in that directory.
+        checkpoint_path = args.resume_from_checkpoint
+
+        try:
+            # We try to find the latest checkpoint in the directory.
+            checkpoint_dirs = os.listdir(checkpoint_path)
+            checkpoint_dirs = [dir for dir in checkpoint_dirs if dir.startswith(f"checkpoint-")] # Checkpoints are intended to be named like "checkpoint-"
+            checkpoint_path = os.path.join(checkpoint_path, sorted(checkpoint_dirs, key=lambda x: int(x.split("-")[-1].split(".")[0]))[-1])
+        except:
+            # If the checkpoint directory does not contain any checkpoints, we will assume
+            # that `resume_from_checkpoint` is already set to the latest checkpoint.
+            pass
+        if master_process:
+            print(f"Resuming training from checkpoint: {checkpoint_path}")
 
     # Start the training
     try:
-        trainer.train(resume_from_checkpoint=args.resume_from_checkpoint)
+        trainer.train(resume_from_checkpoint=checkpoint_path if args.resume_from_checkpoint else None)
     except Exception as e:
         save_path = os.path.join(args.checkpoint_dir, "last")
         trainer.save_model(save_path)
-        print(f"Training failed with error: {e}")
-        print(f"Model saved to 'last' checkpoint at {save_path}")
+        if master_process:
+            print(f"Training failed with error: {e}")
+            print(f"Model saved to 'last' checkpoint at {save_path}")
 
     # Save the final model
     trainer.save_model(os.path.join(args.checkpoint_dir, "final"))

--- a/dpo/dpo_trainer.sh
+++ b/dpo/dpo_trainer.sh
@@ -125,7 +125,7 @@ export ARGS="--dataset_type jsonl \
 --learning_rate 0.000005 \
 --weight_decay 0.0 \
 --lr_scheduler_type cosine \
---warmup_steps 100 \
+--warmup_ratio 0.1 \
 --num_train_epochs 2 \
 --attn_implementation flash_attention_2 \
 --per_device_train_batch_size 8 \

--- a/long_ctx/train_hf.py
+++ b/long_ctx/train_hf.py
@@ -321,15 +321,34 @@ def main(args):
     state.wait_for_everyone()
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
+    
+    if args.resume_from_checkpoint:
+
+        # We expect the `resume_from_checkpoint` argument to be the path to a directory of checkpoints,
+        # the logic below will find the latest checkpoint in that directory.
+        checkpoint_path = args.resume_from_checkpoint
+
+        try:
+            # We try to find the latest checkpoint in the directory.
+            checkpoint_dirs = os.listdir(checkpoint_path)
+            checkpoint_dirs = [dir for dir in checkpoint_dirs if dir.startswith(f"checkpoint-")] # Checkpoints are intended to be named like "checkpoint-"
+            checkpoint_path = os.path.join(checkpoint_path, sorted(checkpoint_dirs, key=lambda x: int(x.split("-")[-1].split(".")[0]))[-1])
+        except:
+            # If the checkpoint directory does not contain any checkpoints, we will assume
+            # that `resume_from_checkpoint` is already set to the latest checkpoint.
+            pass
+        if master_process:
+            print(f"Resuming training from checkpoint: {checkpoint_path}")
 
     # Start the training
     try:
-        trainer.train(resume_from_checkpoint=args.resume_from_checkpoint)
+        trainer.train(resume_from_checkpoint=checkpoint_path if args.resume_from_checkpoint else None)
     except Exception as e:
         save_path = os.path.join(args.checkpoint_dir, "last")
         trainer.save_model(save_path)
-        print(f"Training failed with error: {e}")
-        print(f"Model saved to 'last' checkpoint at {save_path}")
+        if master_process:
+            print(f"Training failed with error: {e}")
+            print(f"Model saved to 'last' checkpoint at {save_path}")
 
     # Save the final model
     trainer.save_model(os.path.join(args.checkpoint_dir, "final"))

--- a/long_ctx/train_hf.py
+++ b/long_ctx/train_hf.py
@@ -629,8 +629,8 @@ if __name__ == "__main__":
         "--report_to", 
         type=str, 
         nargs="+", 
-        default=["wandb", "codecarbon"],
-        help="List of integrations to report results and logs to. Options: 'wandb', 'tensorboard', 'codecarbon', etc."
+        default=None,
+        help="The list of integrations to report the results and logs to. Supported platforms are 'tensorboard', 'wandb', 'comet_ml', 'mlflow', 'clearml', 'wandb' etc. See [here](https://huggingface.co/docs/transformers/main/en/main_classes/trainer#transformers.TrainingArguments.report_to) for more details."
     )
     logging_group.add_argument(
         "--wandb_project", 

--- a/sft/inference_test.py
+++ b/sft/inference_test.py
@@ -269,6 +269,12 @@ def parse_args():
         action="store_true",
         help="Enable 'thinking' mode in chat template."
     )
+    parser.add_argument(
+        "--chat_template_path",
+        type=str,
+        default=None,
+        help="Path to a jinja chat template file. If provided, overrides the tokenizer's chat template."
+    )
     return parser.parse_args()
 
 
@@ -531,19 +537,24 @@ def main():
     # Load model and tokenizer
     print(f"\nLoading model: {args.model_path}")
     tokenizer = AutoTokenizer.from_pretrained(args.model_path)
+    
+    # Load external chat template if provided (ensures train-inference consistency)
+    if args.chat_template_path is not None:
+        print(f"Loading chat template from: {args.chat_template_path}")
+        with open(args.chat_template_path, "r") as f:
+            tokenizer.chat_template = f.read()
+    elif tokenizer.chat_template is None:
+        print("WARNING: Tokenizer has no chat_template! This may cause inference issues.")
 
     model = AutoModelForCausalLM.from_pretrained(
         args.model_path,
-        dtype=torch.float16 if torch.cuda.is_available() else torch.float32,
+        dtype=torch.bfloat16 if torch.cuda.is_available() else torch.float32,
     )
     model.eval()
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Using device: {device}")
     model.to(device)
-
-    if tokenizer.pad_token_id is None:
-        tokenizer.pad_token_id = tokenizer.eos_token_id
 
     generation_config = GenerationConfig(
         do_sample=True,

--- a/sft/inference_test.py
+++ b/sft/inference_test.py
@@ -439,7 +439,11 @@ def generate_markdown_report(samples: list, output_path: str):
                 json_status = "✅ Valid" if checks['valid_json'] else "❌ Invalid"
                 task_specific_info.append(f"- **JSON Validation:** {json_status}")
                 if checks['valid_json'] and checks.get('json_output'):
-                    task_specific_info.append(f"- **JSON Keys:** {list(checks['json_output'].keys())}")
+                    json_output = checks['json_output']
+                    if isinstance(json_output, dict):
+                        task_specific_info.append(f"- **JSON Keys:** {list(json_output.keys())}")
+                    else:
+                        task_specific_info.append(f"- **JSON Output:** {json_output}")
         
         elif task_type == "Function Call / Tool Use":
             if 'made_function_call' in checks:
@@ -494,8 +498,8 @@ def generate_markdown_report(samples: list, output_path: str):
         
         response = response.strip()
         
-        # Truncate very long responses for readability
-        if len(response) > 2000:
+        # Truncate very long responses for readability (only if no EOS token)
+        if len(response) > 2000 and not sample.get('checks', {}).get('has_eos', True):
             md_lines.append(f"**Response:** *(truncated - showing first 2000 of {len(response)} characters)*\n")
             response = response[:2000] + "\n\n[... truncated ...]"
         else:
@@ -555,12 +559,12 @@ def main():
     )
 
     # Helper functions
-    def format_chat(messages: List[Dict[str, str]], tools: List[Dict[str, Any]] = None, enable_thinking: bool = False) -> str:
+    def format_chat(messages: List[Dict[str, str]], tools: List[Dict[str, Any]] = None) -> str:
         """Apply the model chat template safely."""
         kwargs = {
             "tokenize": False,
             "add_generation_prompt": True,
-            "enable_thinking": enable_thinking,
+            "enable_thinking": args.enable_thinking,
         }
         
         if tools:
@@ -571,9 +575,9 @@ def main():
             **kwargs
         )
 
-    def generate_one(messages: List[Dict[str, str]], tools: List[Dict[str, Any]] = None, enable_thinking: bool = False) -> Dict[str, Any]:
+    def generate_one(messages: List[Dict[str, str]], tools: List[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Run a single generation and return text + metadata."""
-        prompt = format_chat(messages, tools=tools, enable_thinking=enable_thinking)
+        prompt = format_chat(messages, tools=tools)
         inputs = tokenizer(prompt, return_tensors="pt").to(device)
 
         with torch.no_grad():
@@ -616,7 +620,6 @@ def main():
             has_neutral = bool(re.search(r"\bneutra\b", text.lower()))
             checks["has_classification_label"] = has_positive or has_negative or has_neutral
             checks["classification_label"] = "Positiva" if has_positive else ("Negativa" if has_negative else ("Neutra" if has_neutral else None))
-
         # Structured JSON output
         if task_type == "Structured Output":
             try:
@@ -672,14 +675,7 @@ def main():
         if tools:
             print(f"Using {len(tools)} tool(s)")
         
-        # Enable thinking for reasoning tasks (or if globally enabled)
-        is_reasoning_task = "reasoning" in task_type.lower()
-        enable_thinking = args.enable_thinking or is_reasoning_task
-        
-        if enable_thinking:
-            print(f"Thinking mode enabled for this task")
-        
-        generation = generate_one(sample["messages"], tools=tools if tools else None, enable_thinking=enable_thinking)
+        generation = generate_one(sample["messages"], tools=tools if tools else None)
         checks = run_task_checks(task_type, generation)
 
         result = {

--- a/sft/sft_trainer.py
+++ b/sft/sft_trainer.py
@@ -229,7 +229,7 @@ def main(args):
         adam_epsilon=args.adam_epsilon,
         max_grad_norm=args.max_grad_norm,
         lr_scheduler_type=args.lr_scheduler_type,
-        warmup_steps=args.warmup_steps,
+        warmup_ratio=args.warmup_ratio,
         num_train_epochs=args.num_train_epochs,
         max_steps=-1 if args.max_steps is None else args.max_steps,
         per_device_train_batch_size=args.per_device_train_batch_size,
@@ -313,7 +313,7 @@ if __name__ == "__main__":
     parser.add_argument("--adam_epsilon", type=float, default=1e-8)
     parser.add_argument("--max_grad_norm", type=float, default=1.0)
     parser.add_argument("--lr_scheduler_type", type=str, default="linear", help="Type of learning rate scheduler to use. Options: 'linear', 'cosine', and all the other types listed [here](https://huggingface.co/docs/transformers/main/en/main_classes/optimizer_schedules#transformers.SchedulerType).")
-    parser.add_argument("--warmup_steps", type=int, default=0)
+    parser.add_argument("--warmup_ratio", type=float, default=0.0)
     parser.add_argument("--num_train_epochs", type=int, default=1)
     parser.add_argument("--max_steps", type=int, default=None, help="Total number of training steps to perform. If set, overrides num_train_epochs.")
     # Precision / performance

--- a/sft/sft_trainer.py
+++ b/sft/sft_trainer.py
@@ -209,7 +209,6 @@ def main(args):
         pad_token=tokenizer.pad_token,
         dataset_num_proc=args.num_proc,
         shuffle_dataset=args.shuffle_dataset,
-        neftune_noise_alpha=args.neftune_noise_alpha,
         use_liger_kernel=args.use_liger_kernel,
         activation_offloading=args.activation_offloading,
         gradient_checkpointing=args.gradient_checkpointing,
@@ -301,7 +300,6 @@ if __name__ == "__main__":
     # The `assistant_only_loss` requires that the chat template supports returning the assistant tokens mask via the {% generation %} keyword.
     parser.add_argument("--assistant_only_loss", action="store_true", help="If set, the loss will only be computed on the assistant's responses, ignoring the user inputs.")
     parser.add_argument("--system_message", type=str, default=None, help="System message to prepend to the user messages. If not set, no system message will be used, and we will default to the chat template's default behavior.")
-    parser.add_argument("--neftune_noise_alpha", type=int, default=5, help="Alpha value for the Neftune noise.")
     # Training and optimizer
     parser.add_argument("--eval_steps", type=int, default=1000)
     parser.add_argument("--save_steps", type=int, default=1000)
@@ -329,7 +327,7 @@ if __name__ == "__main__":
     # Hub / reporting
     parser.add_argument("--hub_token", type=str, default=None)
     parser.add_argument("--hub_model_id", type=str, default=None)
-    parser.add_argument("--report_to", type=str, nargs="+", default=["wandb", "codecarbon"])
+    parser.add_argument("--report_to", type=str, nargs="+", default=None , help="The list of integrations to report the results and logs to. Supported platforms are 'tensorboard', 'wandb', 'comet_ml', 'mlflow', 'clearml', 'wandb' etc. See [here](https://huggingface.co/docs/transformers/main/en/main_classes/trainer#transformers.TrainingArguments.report_to) for more details.")
     parser.add_argument("--wandb_project", type=str, default="Polyglot")
     # Experimental / other
     parser.add_argument("--use_liger_kernel", action="store_true", help="Use the Liger kernel for training. This is an experimental feature that may improve performance on some GPUs.")

--- a/sft/sft_trainer.py
+++ b/sft/sft_trainer.py
@@ -261,15 +261,34 @@ def main(args):
     state.wait_for_everyone()
     if torch.distributed.is_initialized():
         torch.distributed.barrier()
+    
+    if args.resume_from_checkpoint:
+
+        # We expect the `resume_from_checkpoint` argument to be the path to a directory of checkpoints,
+        # the logic below will find the latest checkpoint in that directory.
+        checkpoint_path = args.resume_from_checkpoint
+
+        try:
+            # We try to find the latest checkpoint in the directory.
+            checkpoint_dirs = os.listdir(checkpoint_path)
+            checkpoint_dirs = [dir for dir in checkpoint_dirs if dir.startswith(f"checkpoint-")] # Checkpoints are intended to be named like "checkpoint-"
+            checkpoint_path = os.path.join(checkpoint_path, sorted(checkpoint_dirs, key=lambda x: int(x.split("-")[-1].split(".")[0]))[-1])
+        except:
+            # If the checkpoint directory does not contain any checkpoints, we will assume
+            # that `resume_from_checkpoint` is already set to the latest checkpoint.
+            pass
+        if master_process:
+            print(f"Resuming training from checkpoint: {checkpoint_path}")
 
     # Start the training
     try:
-        trainer.train(resume_from_checkpoint=args.resume_from_checkpoint)
+        trainer.train(resume_from_checkpoint=checkpoint_path if args.resume_from_checkpoint else None)
     except Exception as e:
         save_path = os.path.join(args.checkpoint_dir, "last")
         trainer.save_model(save_path)
-        print(f"Training failed with error: {e}")
-        print(f"Model saved to 'last' checkpoint at {save_path}")
+        if master_process:
+            print(f"Training failed with error: {e}")
+            print(f"Model saved to 'last' checkpoint at {save_path}")
 
     # Save the final model
     trainer.save_model(os.path.join(args.checkpoint_dir, "final"))

--- a/sft/sft_trainer.sh
+++ b/sft/sft_trainer.sh
@@ -137,7 +137,6 @@ export ARGS="--dataset_type jsonl \
 --logging_steps 1 \
 --packing \
 --assistant_only_loss \
---neftune_noise_alpha 5 \
 --use_liger_kernel \
 --learning_rate 0.00005 \
 --weight_decay 0.1 \

--- a/sft/sft_trainer.sh
+++ b/sft/sft_trainer.sh
@@ -142,7 +142,7 @@ export ARGS="--dataset_type jsonl \
 --learning_rate 0.00005 \
 --weight_decay 0.1 \
 --lr_scheduler_type cosine \
---warmup_steps 100 \
+--warmup_ratio 0.1 \
 --num_train_epochs 1 \
 --attn_implementation flash_attention_2 \
 --per_device_train_batch_size 16 \


### PR DESCRIPTION
This pull request enhances some features of our filtering and post-training pipeline:

* Added a new `filter_repetition_loops` function to detect and remove samples with degenerate word repetition patterns from our SFT/Preference datasets. I also introduced other filters for quality control (e.g., `filter_quality_score`), while also making the script more flexible (i.e., we can adapt it for both FTF and preference datasets).
* Moved the token counting step in the processing pipelines (`process_cc_dump.py` and `quality_filters.py`) to occur after formatting cleanup, ensuring accurate token counts post-cleanup.
* Minor improvements for the HF/TRL trainers (e.g., added automatic checkpoint discovery).