### PR TITLE
New synth generation script. Datatrove + vLLM goes brrrrrrr

### DIFF
--- a/synthetic/generate_datatrove.py
+++ b/synthetic/generate_datatrove.py
@@ -1,0 +1,361 @@
+"""
+Single-node script for generating synthetic data using vLLM inference and datatrove pipelines.
+
+Input:  local JSONL or Parquet files.
+Output: local JSONL files.
+
+Supports resuming interrupted jobs via checkpoints — just re-run the same
+command and already-completed chunks will be skipped.
+
+Usage:
+
+    # View all options
+    python generate_datatrove.py --help
+
+    # Basic: generate from local JSONL data
+    python generate_datatrove.py \
+        --input-path /data/prompts \
+        --prompt-column text \
+        --model-name-or-path Qwen/Qwen3-0.6B \
+        --output-path /data/output
+
+    # With a prompt template (must contain [[DOCUMENT]])
+    python generate_datatrove.py \
+        --input-path /data/documents \
+        --prompt-column text \
+        --prompt-template "Summarize the following document: [[DOCUMENT]]" \
+        --model-name-or-path Qwen/Qwen3-0.6B \
+        --output-path /data/summaries
+
+    # Resume an interrupted job (re-run the exact same command)
+    python generate_datatrove.py \
+        --input-path /data/prompts \
+        --prompt-column text \
+        --model-name-or-path Qwen/Qwen3-0.6B \
+        --output-path /data/output
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from datatrove.data import Document
+from datatrove.executor import LocalPipelineExecutor
+from datatrove.pipeline.inference.run_inference import InferenceConfig, InferenceResult, InferenceRunner
+from datatrove.pipeline.readers import JsonlReader, ParquetReader
+from datatrove.pipeline.writers import JsonlWriter
+from datatrove.utils.logging import logger
+
+import torch
+from transformers import AutoConfig, GenerationConfig
+
+# Import normalization and validation utils (utils.py should be in the same directory as this script)
+SCRIPT_DIR = str(Path(__file__).parent)
+sys.path.insert(0, SCRIPT_DIR)
+from utils import (
+    normalize_kvc_dtype,
+    normalize_quantization,
+    normalize_speculative,
+    validate_config,
+)
+
+
+def _detect_input_format(input_path: str) -> str:
+    """Auto-detect input format by inspecting file extensions in the directory."""
+    p = Path(input_path)
+    if not p.is_dir():
+        raise ValueError(f"Input path is not a directory: {input_path}")
+
+    for f in p.rglob("*"):
+        if not f.is_file():
+            continue
+        name = f.name.lower()
+        if name.endswith(".parquet"):
+            return "parquet"
+        if name.endswith(".jsonl") or name.endswith(".jsonl.gz") or name.endswith(".jsonl.zst"):
+            return "jsonl"
+
+    raise ValueError(
+        f"Could not detect input format in {input_path}. "
+        "Expected .jsonl, .jsonl.gz, .jsonl.zst, or .parquet files."
+    )
+
+
+def _compute_reader_limit(max_examples: int, tasks: int) -> int:
+    """Compute per-task reader limit so max_examples is respected globally.
+
+    Each datatrove task applies ``limit`` independently. For multi-task runs
+    this would multiply total output by the number of tasks, so we split the
+    global budget evenly.
+    """
+    if max_examples <= 0:
+        return max_examples
+    if tasks < 1:
+        raise ValueError("tasks must be >= 1 when max_examples is set.")
+    reader_limit = (max_examples + tasks - 1) // tasks
+    if tasks > 1:
+        logger.info(
+            f"Applying global max_examples={max_examples} across {tasks} tasks "
+            f"({reader_limit} docs per task)"
+        )
+    return reader_limit
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Generate synthetic data using vLLM on a single node with local I/O.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # Input and prompt configuration
+    parser.add_argument("--input-path", required=True, help="Directory containing JSONL or Parquet input files")
+    parser.add_argument("--input-format", default="auto", help="Input format: 'jsonl', 'parquet', or 'auto'")
+    parser.add_argument("--prompt-column", default="text", help="Column name containing the prompt text")
+    parser.add_argument("--prompt-template", default=None, help="Template with [[DOCUMENT]] placeholder")
+    parser.add_argument("--max-examples", type=int, default=-1, help="Max total examples to process (-1 = all)")
+
+    # Output configuration
+    parser.add_argument("--output-path", required=True, help="Local directory for output JSONL files")
+
+    # Model and inference configuration
+    parser.add_argument("--server-type", default="vllm", help="Inference server type")
+    parser.add_argument("--model-name-or-path", required=True, help="Model name or local path")
+    parser.add_argument("--model-revision", default="main", help="Model revision")
+    parser.add_argument("--model-max-context", type=int, default=32768, help="Maximum context length")
+    parser.add_argument("--system-prompt", default=None, help="Optional system prompt")
+    parser.add_argument("--trust-remote-code", action="store_true", help="Trust remote code in model repo")
+
+    # Parallelism settings (adjust based on available GPUs and model size)
+    parser.add_argument("--tp", type=int, default=1, help="Tensor parallelism")
+    parser.add_argument("--pp", type=int, default=1, help="Pipeline parallelism")
+    parser.add_argument("--dp", type=int, default=1, help="Data parallelism")
+
+    # vLLM-specific optimizations and settings
+    parser.add_argument("--max-concurrent-generations", type=int, default=500)
+    parser.add_argument("--max-concurrent-documents", type=int, default=500)
+    parser.add_argument("--max-num-seqs", type=int, default=256, help="Max sequences in batch (reduce if OOM)")
+    parser.add_argument("--max-num-batched-tokens", type=int, default=8192, help="Chunked-prefill batch size")
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9, help="Fraction of GPU memory for KV cache")
+    parser.add_argument("--block-size", type=int, default=16, help="KV cache block size (16 or 32)")
+    parser.add_argument("--speculative-config", default=None, help="Speculative decoding config (JSON)")
+    parser.add_argument("--quantization", default=None, help="Quantization method (e.g. bitsandbytes)")
+    parser.add_argument("--kv-cache-dtype", default="auto", help="KV cache dtype: auto, fp8_e4m3, fp8_e5m2")
+    parser.add_argument("--optimization-level", type=int, default=3, help="0 = fast startup, 3 = best throughput")
+    parser.add_argument("--metric-interval", type=int, default=120, help="Metric reporting interval in seconds")
+
+    # Generation settings (overrides model defaults if set)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument("--top-p", type=float, default=None)
+    parser.add_argument("--max-tokens", type=int, default=8192, help="Max output tokens per generation")
+    parser.add_argument("--rollouts-per-document", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducible generation")
+
+    # Processing settings
+    parser.add_argument("--examples-per-chunk", type=int, default=500, help="Documents per checkpoint chunk")
+    parser.add_argument("--tasks", type=int, default=1, help="Number of parallel tasks")
+    parser.add_argument("--workers", type=int, default=1, help="Number of worker processes")
+
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    """Generate synthetic data using vLLM on a single node with local I/O."""
+    # Extract arguments as local variables
+    input_path = args.input_path
+    input_format = args.input_format
+    prompt_column = args.prompt_column
+    prompt_template = args.prompt_template
+    max_examples = args.max_examples
+    output_path = args.output_path
+    server_type = args.server_type
+    model_name_or_path = args.model_name_or_path
+    model_revision = args.model_revision
+    model_max_context = args.model_max_context
+    system_prompt = args.system_prompt
+    trust_remote_code = args.trust_remote_code
+    tp = args.tp
+    pp = args.pp
+    dp = args.dp
+    max_concurrent_generations = args.max_concurrent_generations
+    max_concurrent_documents = args.max_concurrent_documents
+    max_num_seqs = args.max_num_seqs
+    max_num_batched_tokens = args.max_num_batched_tokens
+    gpu_memory_utilization = args.gpu_memory_utilization
+    block_size = args.block_size
+    speculative_config = args.speculative_config
+    quantization = args.quantization
+    kv_cache_dtype = args.kv_cache_dtype
+    optimization_level = args.optimization_level
+    metric_interval = args.metric_interval
+    temperature = args.temperature
+    top_k = args.top_k
+    top_p = args.top_p
+    max_tokens = args.max_tokens
+    rollouts_per_document = args.rollouts_per_document
+    seed = args.seed
+    examples_per_chunk = args.examples_per_chunk
+    tasks = args.tasks
+    workers = args.workers
+
+    # Check for available GPUs and adjust DP accordingly (vLLM requires at least 1 GPU)
+    available_gpus = torch.cuda.device_count()
+    if available_gpus == 0:
+        raise ValueError("At least one CUDA GPU is required.")
+    tp = min(tp, available_gpus)
+    logger.info(f"Running locally on {available_gpus} GPU(s)")
+
+    # Validate model config
+    model_config = AutoConfig.from_pretrained(
+        model_name_or_path, revision=model_revision, trust_remote_code=trust_remote_code
+    )
+    validate_config(tp=tp, pp=pp, dp=dp, config=model_config, prompt_template=prompt_template)
+
+    # Detect input format if set to auto, and initialize reader
+    if input_format == "auto":
+        input_format = _detect_input_format(input_path)
+        logger.info(f"Auto-detected input format: {input_format}")
+
+    reader_limit = _compute_reader_limit(max_examples=max_examples, tasks=tasks)
+
+    if input_format == "parquet":
+        reader = ParquetReader(data_folder=input_path, text_key=prompt_column, limit=reader_limit)
+    elif input_format == "jsonl":
+        reader = JsonlReader(data_folder=input_path, text_key=prompt_column, limit=reader_limit)
+    else:
+        raise ValueError(f"Unsupported input format: {input_format}. Use 'jsonl' or 'parquet'.")
+
+    # Resolve output / checkpoint / log paths
+    output_dir = Path(output_path)
+    checkpoints_dir = str(output_dir / ".checkpoints")
+    logs_dir = str(output_dir / ".logs")
+
+    # Normalize optional configs
+    spec_raw = speculative_config
+    if isinstance(spec_raw, str) and spec_raw.strip().lower() in ("none", "null", ""):
+        spec_raw = None
+    normalized_spec = normalize_speculative(spec_raw)
+    normalized_quant = normalize_quantization(quantization)
+    normalized_kv_dtype = normalize_kvc_dtype(kv_cache_dtype)
+
+    # Resolve generation settings, falling back to model defaults if not set
+    generation_config = GenerationConfig.from_pretrained(
+        model_name_or_path, revision=model_revision, trust_remote_code=trust_remote_code
+    )
+    temperature = temperature if temperature is not None else getattr(generation_config, "temperature", 1.0)
+    top_p = top_p if top_p is not None else getattr(generation_config, "top_p", 1.0)
+    top_k = top_k if top_k is not None else getattr(generation_config, "top_k", -1)
+
+    # Rollout function for a single document
+    async def simple_rollout(
+        document: Document,
+        generate: Callable[[dict[str, Any]], Awaitable[InferenceResult]],
+    ) -> InferenceResult:
+        """Send a single request per document and return the result."""
+        messages = [] if system_prompt is None else [{"role": "system", "content": system_prompt}]
+
+        if isinstance(document.text, list) and all(isinstance(msg, dict) for msg in document.text):
+            if prompt_template:
+                raise ValueError("Prompt template is not supported for message lists")
+            messages.extend(document.text)
+        else:
+            content = (
+                prompt_template.replace("[[DOCUMENT]]", document.text) if prompt_template else document.text
+            )
+
+            # Truncate if content exceeds the context budget (~3 chars/token)
+            char_budget = (model_max_context - max_tokens) * 3
+            if len(content) > char_budget:
+                original_len = len(content)
+                last_newline = content.rfind("\n", 0, char_budget)
+                content = content[:last_newline] if last_newline != -1 else content[:char_budget]
+
+                logger.info(
+                    f"Truncated content from {original_len} to {len(content)} chars "
+                    f"(budget: {char_budget} chars)"
+                )
+
+            messages.append({"role": "user", "content": content})
+
+        return await generate(
+            {
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "top_k": top_k,
+                "top_p": top_p,
+                **({"seed": seed} if seed is not None else {}),
+            }
+        )
+
+    # Build model kwargs with normalized configs
+    quant_kwargs: dict[str, Any] = {}
+    if normalized_quant == "bitsandbytes":
+        quant_kwargs["quantization"] = "bitsandbytes"
+
+    kv_cache_kwargs: dict[str, Any] = {}
+    if normalized_kv_dtype != "auto":
+        kv_cache_kwargs["kv_cache_dtype"] = normalized_kv_dtype
+        kv_cache_kwargs["calculate_kv_scales"] = True
+
+    model_kwargs = {
+        "revision": model_revision,
+        "dtype": "bfloat16",
+        "max_num_seqs": max_num_seqs,
+        "max_num_batched_tokens": max_num_batched_tokens,
+        "block-size": block_size,
+        "gpu-memory-utilization": gpu_memory_utilization,
+        **({"speculative_config": normalized_spec} if normalized_spec else {}),
+        **quant_kwargs,
+        **kv_cache_kwargs,
+        "optimization-level": optimization_level,
+    }
+
+    # Inference configuration for the runner
+    inference_config = InferenceConfig(
+        server_type=server_type,
+        model_name_or_path=model_name_or_path,
+        model_kwargs=model_kwargs,
+        model_max_context=model_max_context,
+        rollouts_per_document=rollouts_per_document,
+        max_concurrent_generations=max_concurrent_generations,
+        max_concurrent_documents=max_concurrent_documents,
+        metric_interval=metric_interval,
+        tp=tp,
+        dp=dp,
+        pp=pp,
+        server_log_folder=str(Path(logs_dir) / "server_logs"),
+    )
+
+    # Pipeline: reader -> inference -> JSONL writer
+    pipeline = [
+        reader,
+        InferenceRunner(
+            rollout_fn=simple_rollout,
+            config=inference_config,
+            records_per_chunk=examples_per_chunk,
+            checkpoints_local_dir=checkpoints_dir,
+            output_writer=JsonlWriter(
+                output_folder=str(output_dir),
+                output_filename="${rank}_${chunk_index}.jsonl",
+                compression=None,
+                expand_metadata=True,
+            ),
+        ),
+    ]
+
+    # Execute the pipeline
+    executor = LocalPipelineExecutor(
+        pipeline=pipeline,
+        logging_dir=logs_dir,
+        tasks=tasks,
+        workers=workers,
+    )
+    executor.run()
+    logger.info(f"Done. Output written to {output_dir}")
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/synthetic/generate_datatrove.sh
+++ b/synthetic/generate_datatrove.sh
@@ -1,0 +1,131 @@
+#!/bin/bash -l
+
+#############################################
+# SLURM Job Configuration
+#############################################
+# Learn more about SLURM options at:
+# - https://slurm.schedmd.com/sbatch.html
+#############################################
+#SBATCH --account=ag_cst_gabriel           # <-- Change to your SLURM account
+#SBATCH --partition=mlgpu_short            # <-- Change to your partition
+#SBATCH --job-name=synthetic-gen
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --threads-per-core=1
+#SBATCH --cpus-per-task=16
+#SBATCH --time=8:00:00
+#SBATCH --gres=gpu:a40:8
+#SBATCH --exclusive
+
+#############################################
+# Working Directory Setup
+#############################################
+username="nklugeco_hpc"                    # <-- Change to the corresponding username that created the workspace
+file_system="scratch"                      # <-- Change to your filesystem
+workspace_name="polyglot_datasets"         # <-- Change to your workspace/project name
+
+workdir="/lustre/$file_system/data/$username-$workspace_name"
+mkdir -p "$workdir/synth/synth_logs"
+cd "$workdir"
+ulimit -c 0
+
+out="$workdir/synth/synth_logs/out.$SLURM_JOB_ID"
+err="$workdir/synth/synth_logs/err.$SLURM_JOB_ID"
+
+#############################################
+# Environment Setup
+#############################################
+source $workdir/.modules_amd.sh                       # <-- Load necessary modules
+# python3 -m venv $workdir/.venv_amd                  # <-- Create virtual environment
+source $workdir/.venv_amd/bin/activate                # <-- Activate virtual environment
+
+# pip3 install --upgrade pip --no-cache-dir
+# pip3 install torch==2.8.0 --no-cache-dir
+# pip3 install torchaudio==2.8.0 --no-cache-dir
+# pip3 install torchvision==0.23.0 --no-cache-dir
+# pip3 install transformers --no-cache-dir
+# pip3 install datatrove[inference] --no-cache-dir
+# pip3 install pyarrow --no-cache-dir
+# pip3 install xxhash --no-cache-dir
+# pip3 install vllm --no-cache-dir
+
+export HF_TOKEN="your_hugging_face_token"               # <-- Change to your Hugging Face token
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
+export HF_DATASETS_CACHE="$workdir/.cache/$SLURM_JOB_ID"
+export HUGGINGFACE_HUB_CACHE="$HF_DATASETS_CACHE"
+export TRITON_CACHE_DIR="$HF_DATASETS_CACHE/triton_cache"
+export CLEAN_CACHE="0"                                  # Set to "1" to clean cache after job completion
+export DP=8                                             # <-- Data parallelism across GPUs
+export TP=1                                             # <-- Tensor parallelism (for bigger models)
+export MODEL_NAME_OR_PATH="Qwen/Qwen3-4B-Instruct-2507" # <-- Change to your model name or path
+export DATASET_PATH="$workdir/portuguese/personas"      # <-- Change to your dataset path (directory with JSONL or Parquet files)
+export TEXT_COLUMN="text"                   # <-- Change to your dataset text column name
+export OUTPUT_DIR="$workdir/synth/personas_bio"    # <-- Change to your desired output directory
+export SYSTEM_PROMPT="Você é um gerador de livros auto biográficos. Seu objetivo é criar livros biográficos detalhados e precisos."          # <-- Change to your system prompt (or leave empty)
+export PROMPT_TEMPLATE="Cria um livro biográfico sobre está pessoa: [[DOCUMENT]]"   # <-- Optional: template with [[DOCUMENT]] placeholder (e.g. "Summarize: [[DOCUMENT]]")
+export MAX_TOKENS=4096                     # <-- Max output tokens per generation
+export MODEL_MAX_CONTEXT=8192              # <-- Maximum context length for the model
+export TEMPERATURE=0.7
+export TOP_K=20
+export TOP_P=0.8
+export ROLLOUTS_PER_DOCUMENT=1
+export EXAMPLES_PER_CHUNK=500               # <-- Documents per checkpoint chunk
+mkdir -p "$OUTPUT_DIR"
+
+if [[ -n "$HF_TOKEN" ]]; then
+    # Login to Hugging Face (if needed)
+    hf auth login --token "$HF_TOKEN"
+fi
+
+echo "# [${SLURM_JOB_ID}] Job started at: $(date)" > "$out"
+echo "# [${SLURM_JOB_ID}] Using $SLURM_NNODES node(s)" >> "$out"
+echo "# [${SLURM_JOB_ID}] Using $DP GPU(s) via data parallelism" >> "$out"
+echo "# [${SLURM_JOB_ID}] Using $TP GPU(s) via tensor parallelism" >> "$out"
+echo "# [${SLURM_JOB_ID}] Running on nodes: $(scontrol show hostnames "$SLURM_NODELIST" | tr '\n' ' ')" >> "$out"
+echo "# Working directory: $workdir" >> "$out"
+echo "# Python executable: $(which python3)" >> "$out"
+
+#############################################
+# Main Job Execution
+#############################################
+# Build optional arguments
+OPTIONAL_ARGS=""
+if [[ -n "$SYSTEM_PROMPT" ]]; then
+    OPTIONAL_ARGS="$OPTIONAL_ARGS --system-prompt \"$SYSTEM_PROMPT\""
+fi
+if [[ -n "$PROMPT_TEMPLATE" ]]; then
+    OPTIONAL_ARGS="$OPTIONAL_ARGS --prompt-template \"$PROMPT_TEMPLATE\""
+fi
+
+# Use eval to properly handle the optional arguments with spaces.
+eval python3 $workdir/synth/generate_datatrove.py \
+    --input-path "$DATASET_PATH" \
+    --prompt-column "$TEXT_COLUMN" \
+    --output-path "$OUTPUT_DIR" \
+    --model-name-or-path "$MODEL_NAME_OR_PATH" \
+    --model-max-context "$MODEL_MAX_CONTEXT" \
+    --dp "$DP" \
+    --tp "$TP" \
+    --max-tokens "$MAX_TOKENS" \
+    --temperature "$TEMPERATURE" \
+    --top-k "$TOP_K" \
+    --top-p "$TOP_P" \
+    --rollouts-per-document "$ROLLOUTS_PER_DOCUMENT" \
+    --examples-per-chunk "$EXAMPLES_PER_CHUNK" \
+    $OPTIONAL_ARGS \
+    1>>"$out" 2>>"$err"
+
+#############################################
+# End of Script
+#############################################
+# Clean HF_DATASETS_CACHE folder if requested
+if [ "$CLEAN_CACHE" = "1" ]; then
+    echo "# [${SLURM_JOB_ID}] Cleaning HF_DATASETS_CACHE" >> "$out"
+    if [ -d "$HF_DATASETS_CACHE" ]; then
+        find "$HF_DATASETS_CACHE" -mindepth 1 -delete 2>/dev/null || true
+    fi
+else
+    echo "# [${SLURM_JOB_ID}] Skipping cache cleanup (CLEAN_CACHE=$CLEAN_CACHE)" >> "$out"
+fi
+
+echo "# [${SLURM_JOB_ID}] Job finished at: $(date)" >> "$out"

--- a/synthetic/utils.py
+++ b/synthetic/utils.py
@@ -1,0 +1,192 @@
+"""Utility functions for the vLLM inference scripts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from datatrove.utils.logging import logger
+
+if TYPE_CHECKING:
+    from transformers import AutoConfig
+
+
+MAX_GPUS_PER_NODE = 8
+
+# Failure pattern definitions: (pattern_string, failure_reason)
+_FAILURE_PATTERNS: list[tuple[str, str]] = [
+    # OOM errors
+    (r"torch\.OutOfMemoryError.*CUDA out of memory", "OOM"),
+    (r"ValueError.*No available memory for the cache blocks", "OOM"),
+    (r"OutOfMemoryError", "OOM"),
+    (r"CUDA out of memory", "OOM"),
+    (r"Failed to load model - not enough GPU memory", "OOM"),
+    # Time limit exceeded
+    (r"DUE TO TIME LIMIT", "timeout"),
+    # Server startup failures
+    (r"Failed to start VLLMServer server", "server_fail"),
+    (r"Server encountered unrecoverable error", "server_fail"),
+]
+FAILURE_PATTERNS = [(re.compile(p, re.IGNORECASE), reason) for p, reason in _FAILURE_PATTERNS]
+
+
+def detect_failure_reason(log_path: Path | None, max_bytes: int = 100_000) -> str | None:
+    """Detect the failure reason from a log file by reading head and tail.
+
+    Args:
+        log_path: Path to the log file to scan.
+        max_bytes: Maximum bytes to read from head/tail of the file.
+
+    Returns:
+        Failure reason string ("OOM", "timeout", "server_fail") or None if no failure detected.
+    """
+    if log_path is None or not log_path.exists():
+        return None
+
+    file_size = log_path.stat().st_size
+    if file_size == 0:
+        return None
+
+    with open(log_path, errors="ignore") as f:
+        # Read tail first (final status like timeout takes priority)
+        if file_size > max_bytes:
+            f.seek(file_size - max_bytes)
+        tail = f.read(max_bytes)
+
+        # Also read head for startup failures (OOM) if file is large
+        f.seek(0)
+        head = f.read(max_bytes) if file_size > max_bytes else ""
+
+    # Check tail first, then head
+    for content in (tail, head):
+        for pattern, reason in FAILURE_PATTERNS:
+            if pattern.search(content):
+                return reason
+    return None
+
+
+# Valid quantization methods
+QUANTIZATION_METHODS = ("bitsandbytes",)
+
+# Valid KV cache dtype options
+KV_CACHE_DTYPE_OPTIONS = ("auto", "fp8_e4m3", "fp8_e5m2")
+
+
+def normalize_speculative(spec) -> str:
+    """
+    Accepts dict/str/bool and returns a canonical JSON string or empty string.
+
+    For ngram method: prompt_lookup_max = num_speculative_tokens - 1 (if present).
+    For suffix method: no additional parameters are added.
+    Any provided prompt_lookup_max in the input is ignored and recomputed for ngram.
+    """
+    if not spec:
+        return ""
+    obj = None
+    if isinstance(spec, dict):
+        obj = dict(spec)
+    elif isinstance(spec, str):
+        try:
+            parsed = json.loads(spec)
+            if isinstance(parsed, dict):
+                obj = parsed
+        except Exception:
+            obj = None
+    else:
+        obj = None
+
+    if isinstance(obj, dict):
+        method = str(obj.get("method", "")).lower()
+        # Only add prompt_lookup_max for ngram method
+        if method == "ngram" and "num_speculative_tokens" in obj:
+            try:
+                n = int(obj["num_speculative_tokens"])
+                obj["prompt_lookup_max"] = max(n - 1, 0)
+            except Exception:
+                obj.pop("prompt_lookup_max", None)
+        return json.dumps(obj, separators=(",", ":"))
+    return str(spec)
+
+
+def normalize_quantization(quant: str | None) -> str | None:
+    """
+    Normalize quantization configuration string.
+
+    Returns:
+        Normalized quantization string or None if disabled.
+
+    Supported methods:
+        - "bitsandbytes": 4-bit quantization using BitsAndBytes
+    """
+    if quant is None:
+        return None
+    if isinstance(quant, str):
+        quant_lower = quant.strip().lower()
+        if quant_lower in ("none", "null", ""):
+            return None
+        if quant_lower in QUANTIZATION_METHODS:
+            return quant_lower
+        raise ValueError(f"Unknown quantization method: {quant}. Supported: {QUANTIZATION_METHODS}")
+    return None
+
+
+def normalize_kvc_dtype(kv_dtype: str | None) -> str:
+    """
+    Normalize KV cache dtype configuration string.
+
+    Returns:
+        Normalized KV cache dtype string. Defaults to "auto".
+
+    Supported options:
+        - "auto": Uses the model's default "unquantized" data type
+        - "fp8_e4m3": FP8 E4M3 format (CUDA 11.8+)
+        - "fp8_e5m2": FP8 E5M2 format (CUDA 11.8+)
+    """
+    if kv_dtype is None:
+        return "auto"
+    if isinstance(kv_dtype, str):
+        kv_lower = kv_dtype.strip().lower()
+        if kv_lower in ("none", "null", ""):
+            return "auto"
+        if kv_lower in KV_CACHE_DTYPE_OPTIONS:
+            return kv_lower
+        raise ValueError(f"Unknown kvc_dtype: {kv_dtype}. Supported: {KV_CACHE_DTYPE_OPTIONS}")
+    return "auto"
+
+
+def validate_config(
+    tp: int,
+    pp: int,
+    dp: int,
+    config: AutoConfig,
+    prompt_template: str | None = None,
+) -> None:
+    """Validate configuration parameters for single-node inference.
+
+    Raises ValueError if any configuration is invalid.
+    """
+    if prompt_template and "[[DOCUMENT]]" not in prompt_template:
+        raise ValueError("Prompt template must contain [[DOCUMENT]] variable")
+
+    if tp < 1:
+        raise ValueError(f"tp must be >= 1, got {tp}.")
+    if pp < 1:
+        raise ValueError(f"pp must be >= 1, got {pp}.")
+    if dp < 1:
+        raise ValueError(f"dp must be >= 1, got {dp}.")
+
+    total_gpus = tp * pp * dp
+    if total_gpus > MAX_GPUS_PER_NODE:
+        raise ValueError(
+            f"TPxPPxDP ({tp}x{pp}x{dp}={total_gpus}) exceeds max GPUs per node ({MAX_GPUS_PER_NODE})."
+        )
+
+    # Check if tp is valid for vLLM
+    # Handle multi-modal configs (e.g., Gemma3) where num_attention_heads is in text_config
+    num_heads = int(getattr(config, "num_attention_heads", None) or config.text_config.num_attention_heads)
+    if num_heads % tp != 0:
+        raise ValueError(
+            f"num_attention_heads ({num_heads}) must be divisible by tensor parallel size (tp={tp})."
+        )


### PR DESCRIPTION
**New synthetic data generation pipeline:**

* Added `generate_datatrove.py`, a script for generating synthetic data from local JSONL or Parquet files using vLLM and datatrove. It supports checkpointing, flexible prompt templating, and a wide range of generation and parallelism options.

* Added `generate_datatrove.sh` for running the synthetic data pipeline on the cluster (Marvin/SLURM). It sets up the environment, configures SLURM job parameters, manages cache and logs, and passes all necessary arguments to the Python script.