### PR TITLE
Fix installation scripts and add document transformation prompts

### DIFF
--- a/synthetic/newPrompts.md
+++ b/synthetic/newPrompts.md
@@ -1,0 +1,63 @@
+# New prompts to try (https://huggingface.co/spaces/HuggingFaceFW/finephrase)
+
+## Artigo
+
+```
+Transforme o documento em um artigo de revista. Comece com uma introdução envolvente e, em seguida, misture narrativa com explicações factuais. Mantenha um tom acessível, porém refinado, adequado a um público geral, porém informado. Produza apenas o artigo, nada mais.
+Documento:
+[[DOCUMENT]]
+```
+
+## Comentário
+
+```
+Resuma o documento em um parágrafo conciso que sintetize seus argumentos ou conclusões centrais. Em seguida, escreva um comentário especializado que reflita criticamente sobre suas implicações, limitações ou contexto mais amplo. Mantenha um tom analítico e profissional ao longo do texto. Produza apenas o resumo e o comentário, nada mais.
+Documento:
+[[DOCUMENT]]
+
+```
+
+## Discussão
+
+```
+Reformule o documento como um diálogo entre um professor e um aluno. O professor deve orientar o aluno para que compreenda os pontos-chave, esclarecendo conceitos complexos. Mantenha a conversa natural, informativa e fiel ao conteúdo original. Produza apenas o diálogo, nada mais.
+Documento:
+[[DOCUMENT]]
+
+```
+
+## FAQ
+
+```
+Reescreva o documento como uma FAQ (Perguntas Frequentes) abrangente. Extraia ou deduza as principais perguntas que um leitor teria sobre este tópico e, em seguida, forneça respostas claras e diretas. Ordene as perguntas de forma lógica — das mais básicas às mais avançadas, ou por área temática. Cada resposta deve ser independente e compreensível sem referência a outras respostas. Certifique-se de que a FAQ funciona como um documento independente. Produza apenas a FAQ, nada mais.
+Documento:
+[[DOCUMENT]]
+
+```
+
+## Matemática
+
+```
+Reescreva o documento para formular um problema matemático com base nos dados numéricos ou nas relações apresentadas no texto. Forneça uma solução passo a passo que mostre claramente o processo de cálculo. Crie um problema que exija raciocínio em várias etapas e operações aritméticas básicas. Ele deve incluir a questão seguida de uma solução detalhada mostrando cada etapa do cálculo. Apresente apenas o problema e a solução, nada mais.
+Documento:
+[[DOCUMENT]]
+
+```
+
+## Tabela
+
+```
+Reescreva o documento como uma tabela estruturada que organize as informações principais e, em seguida, gere um par de perguntas e respostas com base nela. Primeiro, extraia os principais pontos de dados e organize-os em um formato de tabela claro, com cabeçalhos apropriados, usando a sintaxe de tabela markdown com o alinhamento adequado. Após a tabela, gere uma pergunta perspicaz que possa ser respondida usando os dados da tabela. Forneça uma resposta clara e concisa à pergunta com base nas informações da tabela. Gere apenas a tabela seguida do par de perguntas e respostas, nada mais.
+Documento:
+[[DOCUMENT]]
+
+```
+
+## Tutorial
+
+```
+Reescreva o documento como um tutorial ou guia de instruções claro e passo a passo. Use etapas numeradas ou marcadores, quando apropriado, para aumentar a clareza. Preserve todas as informações essenciais, garantindo que o estilo seja didático e fácil de seguir. Produza apenas o tutorial, nada mais.
+Documento:
+[[DOCUMENT]]
+
+```


### PR DESCRIPTION
This pull request adds a new markdown file, `synthetic/newPrompts.md`, which contains a collection of prompt templates for transforming documents into various formats such as articles, summaries, dialogues, FAQs, math problems, tables, and tutorials.

New prompt templates added:

**Document transformation prompts:**
* Added an "Artigo" prompt to convert a document into a magazine-style article with an engaging introduction and a narrative blended with factual explanations.
* Added a "Comentário" prompt for summarizing a document and writing a critical commentary with an analytical tone.
* Added a "Discussão" prompt to reformulate a document as a dialogue between a teacher and a student, clarifying key concepts.
* Added a "FAQ" prompt to rewrite a document as a comprehensive FAQ, extracting and answering key questions in a logical order.
* Added a "Matemática" prompt to transform a document into a multi-step math problem with a detailed solution.
* Added a "Tabela" prompt to organize document data into a markdown table, followed by a Q&A based on the table.
* Added a "Tutorial" prompt to rewrite a document