### PR TITLE
Added struct email task to the gym (it grows!!)

### DIFF
--- a/gym/generate_from_email_templates.py
+++ b/gym/generate_from_email_templates.py
@@ -1,0 +1,478 @@
+"""
+Email structured-extraction task generator.
+
+Reads a JSONL file of emails (one JSON object per line with an "email" key)
+and produces gym-format samples that ask a model to extract specific fields
+from each email as a structured JSON object.
+
+Two categories of fields are supported:
+
+  Direct fields (extracted from email content):
+      subject, sender, receiver, intent, summary
+
+  Injected fields (deterministic values added to the email context):
+      date, attachments, spam, sender_email, telephone_number
+
+For injected fields an explicit metadata header is prepended to the email
+text, and a corresponding ``email:field_value`` verifier is added so the
+extraction can be verified exactly.
+
+Usage:
+    python generate_from_email_templates.py \
+        --emails_file ./data/emails.jsonl \
+        --output_file email_tasks.jsonl \
+        --num_samples 500
+
+    python generate_from_email_templates.py \
+        --emails_file ./data/emails.jsonl \
+        --output_file email_tasks.json \
+        --num_samples 1000 \
+        --min_fields 3 --max_fields 7 \
+        --seed 42 --start_key 0 --verbose
+"""
+
+import json
+import random
+import argparse
+from pathlib import Path
+
+from tasks_metadata import (
+    EMAIL_ALL_FIELDS,
+    EMAIL_DIRECT_FIELDS,
+    EMAIL_INJECTED_FIELDS,
+    EMAIL_FIELD_LABELS,
+    EMAIL_TASK_IDS,
+    EMAIL_DEFAULTS,
+)
+
+
+# Prompt templates
+_PROMPT_PREAMBLES = [
+    "Leia o e-mail abaixo e extraia as informações solicitadas em formato JSON.",
+    "Com base no e-mail a seguir, extraia os campos indicados como objeto JSON.",
+    "A partir do e-mail abaixo, produza um objeto JSON com as informações solicitadas.",
+    "Analise o e-mail a seguir e extraia as informações pedidas em JSON.",
+    "Dado o e-mail abaixo, extraia e organize as informações em um objeto JSON.",
+    "Processe o e-mail a seguir e retorne os dados solicitados como um objeto JSON.",
+    "Leia com atenção o e-mail abaixo e forneça as informações pedidas em JSON.",
+]
+
+_FORMAT_INSTRUCTION = (
+    "Formate sua resposta EXATAMENTE como um bloco JSON markdown, "
+    "sem nenhum texto antes ou depois:\n"
+    "```json\n"
+    "{\n"
+    "  ...\n"
+    "}\n"
+    "```\n"
+    "O JSON deve conter SOMENTE as chaves solicitadas, sem campos adicionais."
+)
+
+
+# ---------------------------------------------------------------------------
+# Random value generators for injected fields
+# ---------------------------------------------------------------------------
+
+_EMAIL_DOMAINS = [
+    "gmail.com",
+    "yahoo.com.br",
+    "hotmail.com",
+    "outlook.com",
+    "empresa.com.br",
+    "trabalho.com.br",
+    "usp.br",
+    "ufmg.br",
+    "mail.com",
+    "protonmail.com",
+]
+
+_FIRST_NAMES = [
+    "carlos", "ana", "pedro", "maria", "joao", "julia",
+    "lucas", "fernanda", "rafael", "camila", "bruno", "mariana",
+    "rodrigo", "patricia", "gustavo", "larissa", "felipe", "sophia",
+    "nicholas", "isabela", "diego", "carolina", "vinicius", "amanda",
+    "gabriel", "bianca", "matheus", "juliana", "ricardo", "marina"
+]
+
+_LAST_NAMES = [
+    "silva", "souza", "oliveira", "santos", "lima",
+    "pereira", "costa", "rodrigues", "alves", "martins",
+    "ferreira", "gomes", "ribeiro", "carvalho", "almeida",
+    "nascimento", "lopes", "machado", "barbosa", "rocha", 
+    "dias", "freitas", "araujo", "melo", "cardoso"
+]
+
+
+def _random_date(rng):
+    """Generate a random ISO 8601 timestamp between 2020 and 2026."""
+    year = rng.randint(2020, 2026)
+    month = rng.randint(1, 12)
+    day = rng.randint(1, 28)
+    hour = rng.randint(0, 23)
+    minute = rng.randint(0, 59)
+    return f"{year}-{month:02d}-{day:02d}T{hour:02d}:{minute:02d}:00"
+
+
+def _random_sender_email(rng):
+    """Generate a plausible Brazilian sender email address."""
+    first = rng.choice(_FIRST_NAMES)
+    last = rng.choice(_LAST_NAMES)
+    domain = rng.choice(_EMAIL_DOMAINS)
+    sep = rng.choice([".", "_", ""])
+    num_suffix = str(rng.randint(1, 99)) if rng.random() < 0.3 else ""
+    return f"{first}{sep}{last}{num_suffix}@{domain}"
+
+
+def _random_phone(rng):
+    """Generate a plausible Brazilian phone number in one of several formats."""
+    ddd = rng.choice(["11", "21", "31", "41", "51", "61", "71", "81", "91"])
+    prefix = rng.choice(["98", "99", "97", "96"])
+    part1 = f"{rng.randint(1000, 9999)}"
+    part2 = f"{rng.randint(1000, 9999)}"
+    fmt = rng.choice([
+        f"({ddd}) {prefix}{part1}-{part2}",
+        f"+55 {ddd} {prefix}{part1}-{part2}",
+        f"+55 ({ddd}) {prefix}{part1}-{part2}",
+        f"{ddd} {prefix}{part1}-{part2}",
+    ])
+    return fmt
+
+
+def generate_injected_values(rng):
+    """Generate random values for all five injected fields.
+
+    Returns a dict with keys: date, attachments, spam, sender_email,
+    telephone_number.
+    """
+    return {
+        "date": _random_date(rng),
+        "attachments": rng.random() < 0.3,
+        "spam": rng.random() < 0.1,
+        "sender_email": _random_sender_email(rng),
+        "telephone_number": _random_phone(rng),
+    }
+
+
+
+# Email context construction
+def _injected_label(field, value):
+    """Return the Portuguese header line for a single injected field."""
+    if field == "date":
+        return f"Data de recebimento: {value}"
+    if field == "attachments":
+        return f"Anexos: {'Sim' if value else 'Não'}"
+    if field == "spam":
+        return f"Classificação de spam: {'Sim' if value else 'Não'}"
+    if field == "sender_email":
+        return f"E-mail do remetente: {value}"
+    if field == "telephone_number":
+        return f"Telefone de contato: {value}"
+    return f"{field}: {value}"
+
+
+def build_email_context(email_text, injected_values):
+    """Prepend a structured metadata header to the email text.
+
+    The header contains all five injected fields so the model can read
+    them directly, regardless of which subset is requested.
+    """
+    header_lines = ["--- Metadados do E-mail ---"]
+    for field in EMAIL_INJECTED_FIELDS:
+        header_lines.append(_injected_label(field, injected_values[field]))
+    header_lines.append("---")
+    return "\n".join(header_lines) + "\n\n" + email_text
+
+
+# Sample construction
+def build_email_sample(email_text, key, fields, injected_values, rng):
+    """Build one email extraction gym sample.
+
+    Args:
+        email_text: Raw email content (will have metadata header prepended).
+        key: Integer identifier for this sample.
+        fields: List of field names to request in the output JSON.
+        injected_values: Dict of all five injected field values.
+        rng: ``random.Random`` instance for reproducibility.
+
+    Returns:
+        Dict with keys: key, prompt, verifier_id_list, kwargs.
+    """
+    email_with_meta = build_email_context(email_text, injected_values)
+
+    # Describe requested fields
+    field_details = "\n".join(
+        f"  - {EMAIL_FIELD_LABELS[f]}" for f in fields
+    )
+    fields_str = ", ".join(fields)
+
+    preamble = rng.choice(_PROMPT_PREAMBLES)
+    prompt = (
+        f"{preamble}\n\n"
+        f"Campos solicitados:\n{field_details}\n\n"
+        f"E-mail:\n{email_with_meta}\n\n"
+        f"{_FORMAT_INSTRUCTION}\n"
+        f"Chaves obrigatórias: {fields_str}"
+    )
+
+    # Always include the two format verifiers
+    verifier_id_list = ["email:json_format", "email:schema_keys"]
+    kwargs_list = [
+        {},                                        # email:json_format — no kwargs
+        {"required_keys": sorted(fields)},         # email:schema_keys
+    ]
+
+    # Exact-match verifiers for every injected field that was requested
+    for field in fields:
+        if field in EMAIL_INJECTED_FIELDS:
+            verifier_id_list.append("email:field_value")
+            kwargs_list.append({
+                "field_name": field,
+                "expected_value": injected_values[field],
+            })
+
+    return {
+        "key": key,
+        "prompt": prompt,
+        "verifier_id_list": verifier_id_list,
+        "kwargs": kwargs_list,
+    }
+
+
+# Validation
+def validate_email_sample(sample):
+    """Return a list of validation issues for an email sample (empty = valid)."""
+    issues = []
+
+    n_ids = len(sample.get("verifier_id_list", []))
+    n_kw = len(sample.get("kwargs", []))
+    if n_ids != n_kw:
+        issues.append(
+            f"verifier_id_list length ({n_ids}) != kwargs length ({n_kw})"
+        )
+
+    for iid in sample.get("verifier_id_list", []):
+        if iid not in EMAIL_TASK_IDS:
+            issues.append(f"Unknown email task ID: {iid}")
+
+    if not sample.get("prompt", "").strip():
+        issues.append("Empty prompt")
+
+    vids = sample.get("verifier_id_list", [])
+    if "email:json_format" not in vids:
+        issues.append("Missing email:json_format verifier")
+    if "email:schema_keys" not in vids:
+        issues.append("Missing email:schema_keys verifier")
+
+    for i, iid in enumerate(vids):
+        kw = sample["kwargs"][i] if i < len(sample.get("kwargs", [])) else {}
+        if iid == "email:schema_keys":
+            keys = kw.get("required_keys", [])
+            if not keys:
+                issues.append("email:schema_keys has empty required_keys")
+            else:
+                for k in keys:
+                    if k not in EMAIL_ALL_FIELDS:
+                        issues.append(f"Unknown field in required_keys: {k}")
+        elif iid == "email:field_value":
+            if not kw.get("field_name"):
+                issues.append("email:field_value missing field_name")
+            if "expected_value" not in kw:
+                issues.append("email:field_value missing expected_value")
+
+    return issues
+
+
+def sample_fingerprint(sample):
+    """Hashable fingerprint for deduplication."""
+    return sample["prompt"]
+
+
+# Data loading
+def load_emails(emails_file):
+    """Load emails from a JSONL file.
+
+    Each line must be a JSON object with an ``"email"`` key.
+    Returns a list of email strings.
+    """
+    path = Path(emails_file)
+    if not path.exists():
+        raise FileNotFoundError(f"Emails file not found: {emails_file}")
+
+    emails = []
+    with open(path, encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON on line {line_no} of {emails_file}"
+                ) from exc
+            if "email" not in obj:
+                raise ValueError(
+                    f"Line {line_no} in {emails_file} has no 'email' key"
+                )
+            text = obj["email"].strip()
+            if text:
+                emails.append(text)
+    return emails
+
+
+# Main generation loop
+def main(args):
+    output_path = Path(args.output_file)
+
+    emails = load_emails(args.emails_file)
+    if not emails:
+        print("Error: no usable emails found in the input file.")
+        return
+
+    min_fields = max(1, args.min_fields)
+    max_fields = min(args.max_fields, len(EMAIL_ALL_FIELDS))
+    if min_fields > max_fields:
+        raise ValueError(
+            f"--min_fields ({min_fields}) > --max_fields ({max_fields})"
+        )
+
+    print(
+        f"Loaded {len(emails)} emails. "
+        f"Generating {args.num_samples} samples "
+        f"(fields={min_fields}-{max_fields}, seed={args.seed})"
+    )
+
+    samples = []
+    seen = set()
+    key_counter = args.start_key
+    retries_used = 0
+    max_retries = 20
+
+    for i in range(args.num_samples):
+        sample = None
+
+        for attempt in range(max_retries):
+            rng = random.Random(args.seed + i * max_retries + attempt)
+
+            email_text = rng.choice(emails)
+            injected = generate_injected_values(rng)
+
+            num_fields = rng.randint(min_fields, max_fields)
+            fields = rng.sample(EMAIL_ALL_FIELDS, num_fields)
+
+            candidate = build_email_sample(
+                email_text=email_text,
+                key=key_counter,
+                fields=fields,
+                injected_values=injected,
+                rng=rng,
+            )
+
+            fp = sample_fingerprint(candidate)
+            if fp not in seen:
+                sample = candidate
+                seen.add(fp)
+                break
+
+            retries_used += 1
+
+        if sample is None:
+            print(f"  Warning: could not produce unique sample #{i + 1}")
+            continue
+
+        samples.append(sample)
+        key_counter += 1
+
+    # Validate all samples
+    total_issues = 0
+    for s in samples:
+        issues = validate_email_sample(s)
+        if issues:
+            total_issues += len(issues)
+            if args.verbose:
+                print(f"  Key {s['key']}: {issues}")
+
+    unique_fps = len({sample_fingerprint(s) for s in samples})
+
+    print(f"\nResults:")
+    print(f"  Generated samples:  {len(samples)}")
+    print(
+        f"  Unique:             {unique_fps}/{len(samples)}"
+        f"  ({100 * unique_fps / max(len(samples), 1):.1f}%)"
+    )
+    print(f"  Validation issues:  {total_issues}")
+    if retries_used:
+        print(f"  Retries used:       {retries_used}")
+
+    assert total_issues == 0, f"FAIL: {total_issues} validation issues found"
+    assert unique_fps == len(samples), (
+        f"FAIL: {len(samples) - unique_fps} duplicate samples"
+    )
+
+    use_jsonl = output_path.suffix.lower() == ".jsonl"
+    with open(output_path, "w", encoding="utf-8") as f:
+        if use_jsonl:
+            for s in samples:
+                f.write(json.dumps(s, ensure_ascii=False) + "\n")
+        else:
+            json.dump(samples, f, ensure_ascii=False, indent=2)
+
+    fmt = "JSONL" if use_jsonl else "JSON"
+    print(f"\nOutput written to: {output_path} ({fmt})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Email structured-extraction task generator.",
+    )
+    parser.add_argument(
+        "--emails_file",
+        type=str,
+        required=True,
+        help="Path to the JSONL file containing emails (one per line, 'email' key).",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        required=True,
+        help="Path for the output JSON or JSONL file.",
+    )
+    parser.add_argument(
+        "--num_samples",
+        type=int,
+        default=EMAIL_DEFAULTS["min_fields"] * 100,
+        help="Number of samples to generate (default: 300).",
+    )
+    parser.add_argument(
+        "--min_fields",
+        type=int,
+        default=EMAIL_DEFAULTS["min_fields"],
+        help=f"Minimum number of JSON fields to request per sample "
+             f"(default: {EMAIL_DEFAULTS['min_fields']}).",
+    )
+    parser.add_argument(
+        "--max_fields",
+        type=int,
+        default=EMAIL_DEFAULTS["max_fields"],
+        help=f"Maximum number of JSON fields to request per sample "
+             f"(default: {EMAIL_DEFAULTS['max_fields']}).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility (default: 42).",
+    )
+    parser.add_argument(
+        "--start_key",
+        type=int,
+        default=0,
+        help="Starting integer key for generated samples (default: 0).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print per-sample validation warnings.",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/gym/tasks_metadata.py
+++ b/gym/tasks_metadata.py
@@ -656,3 +656,67 @@ def generate_math_task_description(task_id):
             "Resolver um problema matemático e fornecer a resposta numérica correta.",
     }
     return descriptions.get(task_id, "")
+
+
+# Email Extraction Tasks
+_EMAIL = "email:"
+
+# Fields extractable directly from email content (no injection needed)
+EMAIL_DIRECT_FIELDS = [
+    "subject",          # Assunto do e-mail
+    "sender",           # Nome do remetente
+    "receiver",         # Nome do destinatário
+    "intent",           # Intenção/propósito do e-mail
+    "summary",          # Resumo breve do conteúdo
+]
+
+# Fields synthetically injected into the email context at generation time,
+# enabling deterministic verification via exact-match.
+EMAIL_INJECTED_FIELDS = [
+    "date",             # Data/hora de recebimento (ISO 8601)
+    "attachments",      # Presença de anexos (booleano)
+    "spam",             # Classificação de spam (booleano)
+    "sender_email",     # Endereço de e-mail do remetente
+    "telephone_number", # Número de telefone mencionado
+]
+
+EMAIL_ALL_FIELDS = EMAIL_DIRECT_FIELDS + EMAIL_INJECTED_FIELDS
+
+# Portuguese field-description labels used inside prompts
+EMAIL_FIELD_LABELS = {
+    "subject":          "subject (assunto do e-mail)",
+    "sender":           "sender (nome do remetente)",
+    "receiver":         "receiver (nome do destinatário)",
+    "intent":           "intent (intenção/propósito principal do e-mail)",
+    "summary":          "summary (resumo breve do conteúdo)",
+    "date":             "date (data de recebimento conforme cabeçalho, formato ISO 8601)",
+    "attachments":      "attachments (true se há anexos, false caso contrário)",
+    "spam":             "spam (true se é spam, false caso contrário)",
+    "sender_email":     "sender_email (endereço de e-mail do remetente)",
+    "telephone_number": "telephone_number (número de telefone mencionado no e-mail)",
+}
+
+EMAIL_TASK_IDS = [
+    _EMAIL + "json_format",
+    _EMAIL + "schema_keys",
+    _EMAIL + "field_value",
+]
+
+EMAIL_DEFAULTS = {
+    "min_fields": 3,
+    "max_fields": 7,
+    "tokens_to_generate": 300,
+}
+
+
+def generate_email_task_description(task_id):
+    """Return a brief Portuguese description for an email extraction task ID."""
+    descriptions = {
+        _EMAIL + "json_format":
+            "Formatar a resposta como objeto JSON válido dentro de bloco markdown.",
+        _EMAIL + "schema_keys":
+            "O JSON deve conter exatamente as chaves solicitadas.",
+        _EMAIL + "field_value":
+            "Um campo específico deve ter o valor exato esperado.",
+    }
+    return descriptions.get(task_id, "")

--- a/gym/tests.py
+++ b/gym/tests.py
@@ -813,6 +813,286 @@ print("Test 18 — math end-to-end (build + validate + verify): OK ✓")
 
 # %%
 #######################################
+# 19. Email JSON format verifier — pass, fail, edge cases
+#######################################
+from generate_from_email_templates import (
+    build_email_sample,
+    validate_email_sample,
+    generate_injected_values,
+)
+from tasks_metadata import (
+    EMAIL_TASK_IDS,
+    EMAIL_ALL_FIELDS,
+    EMAIL_INJECTED_FIELDS,
+)
+
+# Pass: valid JSON object in ```json``` block
+v = Verifier(
+    verifier_id_list=["email:json_format"],
+    kwargs=[{}],
+    completion='```json\n{"subject": "Reunião"}\n```',
+)
+assert v.verify() == [True]
+
+# Pass: ```JSON``` specifier (uppercase) accepted
+v2 = Verifier(
+    verifier_id_list=["email:json_format"],
+    kwargs=[{}],
+    completion='```JSON\n{"subject": "Teste", "sender": "Ana"}\n```',
+)
+assert v2.verify() == [True]
+
+# Fail: raw JSON without fenced block
+v3 = Verifier(
+    verifier_id_list=["email:json_format"],
+    kwargs=[{}],
+    completion='{"subject": "Reunião"}',
+)
+assert v3.verify() == [False], "Raw JSON without code block should fail"
+
+# Fail: fenced block with invalid JSON syntax
+v4 = Verifier(
+    verifier_id_list=["email:json_format"],
+    kwargs=[{}],
+    completion='```json\n{subject: Reunião}\n```',
+)
+assert v4.verify() == [False], "Invalid JSON syntax should fail"
+
+# Fail: plain text response
+v5 = Verifier(
+    verifier_id_list=["email:json_format"],
+    kwargs=[{}],
+    completion="O assunto do e-mail é Reunião.",
+)
+assert v5.verify() == [False]
+
+# Pass: multi-field JSON with booleans
+v6 = Verifier(
+    verifier_id_list=["email:json_format"],
+    kwargs=[{}],
+    completion='```json\n{"subject": "Reunião", "spam": false, "attachments": true}\n```',
+)
+assert v6.verify() == [True]
+print("Test 19 — email:json_format verifier (pass/fail/edge): OK ✓")
+
+# %%
+#######################################
+# 20. Email schema keys verifier — pass, fail, edge cases
+#######################################
+# Pass: exact key match — single key
+v = Verifier(
+    verifier_id_list=["email:schema_keys"],
+    kwargs=[{"required_keys": ["subject"]}],
+    completion='```json\n{"subject": "Proposta Comercial"}\n```',
+)
+assert v.verify() == [True]
+
+# Pass: exact key match — multiple keys
+v2 = Verifier(
+    verifier_id_list=["email:schema_keys"],
+    kwargs=[{"required_keys": ["subject", "sender", "spam"]}],
+    completion='```json\n{"subject": "Proposta", "sender": "Carlos", "spam": false}\n```',
+)
+assert v2.verify() == [True]
+
+# Fail: missing required key
+v3 = Verifier(
+    verifier_id_list=["email:schema_keys"],
+    kwargs=[{"required_keys": ["subject", "sender", "spam"]}],
+    completion='```json\n{"subject": "Proposta", "sender": "Carlos"}\n```',
+)
+assert v3.verify() == [False], "Missing key 'spam' should fail"
+
+# Fail: extra key not in required_keys
+v4 = Verifier(
+    verifier_id_list=["email:schema_keys"],
+    kwargs=[{"required_keys": ["subject"]}],
+    completion='```json\n{"subject": "Proposta", "sender": "Carlos"}\n```',
+)
+assert v4.verify() == [False], "Extra key 'sender' should fail"
+
+# Fail: no parseable JSON
+v5 = Verifier(
+    verifier_id_list=["email:schema_keys"],
+    kwargs=[{"required_keys": ["subject"]}],
+    completion="Não é JSON.",
+)
+assert v5.verify() == [False]
+
+# Pass: key order does not matter
+v6 = Verifier(
+    verifier_id_list=["email:schema_keys"],
+    kwargs=[{"required_keys": ["sender", "subject"]}],
+    completion='```json\n{"subject": "Teste", "sender": "Maria"}\n```',
+)
+assert v6.verify() == [True], "Key order should not matter"
+print("Test 20 — email:schema_keys verifier (pass/fail/edge): OK ✓")
+
+# %%
+#######################################
+# 21. Email field value verifier — pass, fail, edge cases (str + bool)
+#######################################
+# Pass: string field exact match
+v = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "date", "expected_value": "2023-04-15T11:30:00"}],
+    completion='```json\n{"date": "2023-04-15T11:30:00"}\n```',
+)
+assert v.verify() == [True]
+
+# Fail: wrong string value
+v2 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "date", "expected_value": "2023-04-15T11:30:00"}],
+    completion='```json\n{"date": "2024-12-01T09:00:00"}\n```',
+)
+assert v2.verify() == [False]
+
+# Pass: boolean False field
+v3 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "spam", "expected_value": False}],
+    completion='```json\n{"spam": false}\n```',
+)
+assert v3.verify() == [True]
+
+# Pass: boolean True field
+v4 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "attachments", "expected_value": True}],
+    completion='```json\n{"attachments": true}\n```',
+)
+assert v4.verify() == [True]
+
+# Fail: wrong boolean value
+v5 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "spam", "expected_value": False}],
+    completion='```json\n{"spam": true}\n```',
+)
+assert v5.verify() == [False], "Expected False but got True"
+
+# Fail: field missing from JSON
+v6 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "spam", "expected_value": False}],
+    completion='```json\n{"subject": "Teste"}\n```',
+)
+assert v6.verify() == [False], "Missing field should fail"
+
+# Pass: sender_email string match
+v7 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "sender_email", "expected_value": "carlos.silva@empresa.com"}],
+    completion='```json\n{"sender_email": "carlos.silva@empresa.com"}\n```',
+)
+assert v7.verify() == [True]
+
+# Pass: raw JSON accepted for field_value (lenient parsing)
+v8 = Verifier(
+    verifier_id_list=["email:field_value"],
+    kwargs=[{"field_name": "spam", "expected_value": False}],
+    completion='{"spam": false, "subject": "Oi"}',
+)
+assert v8.verify() == [True], "field_value should accept raw JSON"
+print("Test 21 — email:field_value verifier (pass/fail/edge): OK ✓")
+
+# %%
+#######################################
+# 22. Email — end-to-end build + validate + verify
+#######################################
+import json as _json_mod
+
+_test_email = (
+    "Assunto: Proposta de Parceria\n\n"
+    "Olá Maria,\n\n"
+    "Gostaria de apresentar uma proposta de parceria entre nossas empresas.\n"
+    "Temos interesse em colaborar no próximo trimestre.\n\n"
+    "Aguardo seu retorno.\n\nAbraços,\nCarlos"
+)
+
+rng_test = random.Random(42)
+_injected = generate_injected_values(rng_test)
+
+_fields = ["subject", "sender", "spam", "date", "attachments"]
+
+sample_email = build_email_sample(
+    email_text=_test_email,
+    key=100,
+    fields=_fields,
+    injected_values=_injected,
+    rng=rng_test,
+)
+
+# Structural assertions
+assert sample_email["key"] == 100
+assert "email:json_format" in sample_email["verifier_id_list"]
+assert "email:schema_keys" in sample_email["verifier_id_list"]
+assert len(sample_email["verifier_id_list"]) == len(sample_email["kwargs"])
+
+# Validate the sample
+issues_email = validate_email_sample(sample_email)
+assert issues_email == [], f"Email sample has issues: {issues_email}"
+
+# Count expected field_value verifiers (spam, date, attachments are injected)
+fv_count = sample_email["verifier_id_list"].count("email:field_value")
+injected_requested = [f for f in _fields if f in EMAIL_INJECTED_FIELDS]
+assert fv_count == len(injected_requested), (
+    f"Expected {len(injected_requested)} field_value verifiers, got {fv_count}"
+)
+
+# Build a correct completion using the known injected values
+schema_idx = sample_email["verifier_id_list"].index("email:schema_keys")
+req_keys = sample_email["kwargs"][schema_idx]["required_keys"]
+correct_obj = {}
+for k in req_keys:
+    if k in EMAIL_INJECTED_FIELDS:
+        for i, iid in enumerate(sample_email["verifier_id_list"]):
+            if iid == "email:field_value" and sample_email["kwargs"][i]["field_name"] == k:
+                correct_obj[k] = sample_email["kwargs"][i]["expected_value"]
+                break
+    elif k == "subject":
+        correct_obj[k] = "Proposta de Parceria"
+    elif k == "sender":
+        correct_obj[k] = "Carlos"
+    else:
+        correct_obj[k] = "valor genérico"
+
+correct_completion = "```json\n" + _json_mod.dumps(correct_obj, ensure_ascii=False) + "\n```"
+
+v_email = Verifier(
+    verifier_id_list=sample_email["verifier_id_list"],
+    kwargs=sample_email["kwargs"],
+    completion=correct_completion,
+)
+results_email = v_email.verify()
+assert results_email[0] == True, f"email:json_format failed: {correct_completion}"
+assert results_email[1] == True, f"email:schema_keys failed: {correct_completion}"
+for i, (iid, res) in enumerate(zip(sample_email["verifier_id_list"], results_email)):
+    if iid == "email:field_value":
+        assert res == True, (
+            f"email:field_value[{i}] failed for field "
+            f"'{sample_email['kwargs'][i]['field_name']}': {correct_completion}"
+        )
+
+# A wrong completion must fail schema_keys
+wrong_completion = '```json\n{"wrong_key": "value"}\n```'
+v_wrong = Verifier(
+    verifier_id_list=sample_email["verifier_id_list"],
+    kwargs=sample_email["kwargs"],
+    completion=wrong_completion,
+)
+results_wrong = v_wrong.verify()
+assert results_wrong[1] == False, "schema_keys should fail for wrong keys"
+
+# All EMAIL_TASK_IDS must be in VERIFICATION_REGISTRY
+for tid in EMAIL_TASK_IDS:
+    assert tid in VERIFICATION_REGISTRY, f"Missing registry entry for {tid}"
+
+print("Test 22 — email end-to-end (build + validate + verify): OK ✓")
+
+# %%
+#######################################
 # Summary
 #######################################
 print("\n" + "=" * 40)

--- a/gym/verifier.py
+++ b/gym/verifier.py
@@ -27,6 +27,9 @@ from verifiers import (
     CommonWordsChecker,
     ConstrainedResponseChecker,
     CountWordChecker,
+    EmailFieldValueChecker,
+    EmailJsonFormatChecker,
+    EmailSchemaKeysChecker,
     EndChecker,
     ForbiddenWords,
     FrequencyComparisonChecker,
@@ -99,6 +102,10 @@ VERIFICATION_REGISTRY = {
     "haystack:needle_uuid": NeedleUUIDChecker,
     # Math tasks (verifying correct numerical answer)
     "math:answer_check": MathAnswerChecker,
+    # Email extraction tasks
+    "email:json_format": EmailJsonFormatChecker,
+    "email:schema_keys": EmailSchemaKeysChecker,
+    "email:field_value": EmailFieldValueChecker,
 }
 
 

--- a/gym/verifiers.py
+++ b/gym/verifiers.py
@@ -1844,3 +1844,131 @@ class MathAnswerChecker(TaskVerifier):
         if not self._expected_answer:
             return False
         return self._expected_answer in value
+
+
+def _extract_email_json(value):
+    """Extract and parse a JSON object from a response string.
+
+    Accepts both ```json...``` (or ```) code blocks and raw JSON strings.
+    Returns a dict on success, or None if parsing fails.
+    """
+    stripped = value.strip()
+    # Try to extract from a fenced code block first
+    m = re.search(r"```(?:json|JSON|Json)?\s*(.*?)\s*```", stripped, re.DOTALL)
+    if m:
+        try:
+            obj = json.loads(m.group(1))
+            if isinstance(obj, dict):
+                return obj
+        except (ValueError, json.JSONDecodeError):
+            pass
+    # Fall back to parsing the whole string as JSON
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict):
+            return obj
+    except (ValueError, json.JSONDecodeError):
+        pass
+    return None
+
+
+class EmailJsonFormatChecker(TaskVerifier):
+    """Checks that the response is a valid JSON object inside a ```json``` block."""
+
+    def build_description(self):
+        self._description_pattern = (
+            "Formate sua resposta EXATAMENTE como um bloco JSON markdown:\n"
+            "```json\n{\n  ...\n}\n```\n"
+            "O JSON deve conter apenas as chaves solicitadas, sem texto adicional."
+        )
+        return self._description_pattern
+
+    def get_instruction_args(self):
+        return None
+
+    def get_instruction_args_keys(self):
+        return []
+
+    def check_following(self, value):
+        """Return True only if response has a ```json``` block with a valid JSON object."""
+        stripped = value.strip()
+        # Require a fenced code block with json/JSON/Json specifier or plain ```
+        if not re.search(r"```(?:json|JSON|Json)?", stripped):
+            return False
+        return _extract_email_json(value) is not None
+
+
+class EmailSchemaKeysChecker(TaskVerifier):
+    """Checks that the JSON response contains exactly the required keys."""
+
+    def build_description(self, *, required_keys=None):
+        self._required_keys = sorted(required_keys or [])
+        self._description_pattern = (
+            "O objeto JSON deve conter EXATAMENTE as chaves: {keys}. "
+            "Nenhuma chave adicional ou faltante é permitida."
+        )
+        return self._description_pattern.format(keys=", ".join(self._required_keys))
+
+    def get_instruction_args(self):
+        return {"required_keys": self._required_keys}
+
+    def get_instruction_args_keys(self):
+        return ["required_keys"]
+
+    def check_following(self, value):
+        """Return True if the JSON object has exactly the required keys."""
+        obj = _extract_email_json(value)
+        if obj is None:
+            return False
+        return set(obj.keys()) == set(self._required_keys)
+
+
+class EmailFieldValueChecker(TaskVerifier):
+    """Checks that a specific field in the JSON response matches the expected value.
+
+    Supports both string and boolean expected values.  For booleans the model
+    output may be a JSON boolean (True/False) or a string representation.
+    """
+
+    def build_description(self, *, field_name=None, expected_value=None):
+        self._field_name = field_name or ""
+        self._expected_value = expected_value
+        if isinstance(self._expected_value, bool):
+            val_str = "true" if self._expected_value else "false"
+        else:
+            val_str = str(self._expected_value)
+        self._description_pattern = (
+            "O campo \"{field}\" deve ter o valor: {value}."
+        )
+        return self._description_pattern.format(
+            field=self._field_name, value=val_str
+        )
+
+    def get_instruction_args(self):
+        return {
+            "field_name": self._field_name,
+            "expected_value": self._expected_value,
+        }
+
+    def get_instruction_args_keys(self):
+        return ["field_name", "expected_value"]
+
+    def check_following(self, value):
+        """Return True if the JSON field matches the expected value."""
+        obj = _extract_email_json(value)
+        if obj is None or self._field_name not in obj:
+            return False
+        actual = obj[self._field_name]
+        if isinstance(self._expected_value, bool):
+            if isinstance(actual, bool):
+                return actual == self._expected_value
+            if isinstance(actual, str):
+                true_strs = {"true", "sim", "verdadeiro", "yes"}
+                false_strs = {"false", "não", "nao", "falso", "no"}
+                return (
+                    actual.lower() in true_strs
+                    if self._expected_value
+                    else actual.lower() in false_strs
+                )
+            return False
+        return str(actual).strip() == str(self._expected_value).strip()


### PR DESCRIPTION
This pull request adds support for email extraction tasks, including new task definitions, verifier implementations, and tests to ensure correct behavior for various email-related JSON extraction scenarios.

**Email Extraction Task Definitions and Metadata**
- Adds new email extraction task IDs (such as `email:json_format`, `email:schema_keys`, `email:field_value`) and associated metadata, including field lists, labels, and default values in `tasks_metadata.py`. Also added a function to generate Portuguese descriptions for these tasks.

**Verifier Implementations for Email Tasks**
- Implemented three new verifier classes in `verifiers.py`: `EmailJsonFormatChecker` (checks for valid JSON in a fenced block), `EmailSchemaKeysChecker` (checks for exact key match), and `EmailFieldValueChecker` (checks for specific field value match, supporting both string and boolean fields). Added a utility function `_extract_email_json` to parse JSON from both fenced code blocks and raw strings.
- Registered these new verifiers in the main verifier registry in `verifier.py`, enabling them to be used for automated evaluation.

**Testing and Validation**
- Added tests in `tests.py` to cover all new email extraction verifiers, including pass, fail, and edge cases for JSON formatting, schema key matching, and field value checking.