### PR TITLE
added tool calling tasks

### DIFF
--- a/gym/data/tools.json
+++ b/gym/data/tools.json
@@ -1,0 +1,8988 @@
+{
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter moeda de uma moeda para outra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor a ser convertido."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Recupere detalhes sobre um filme.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "movie_title": {
+              "type": "string",
+              "description": "O título do filme."
+            }
+          },
+          "required": [
+            "movie_title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age_difference",
+        "description": "Calcule a diferença de idade entre duas pessoas.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "person1_age": {
+              "type": "integer",
+              "description": "A idade da primeira pessoa."
+            },
+            "person2_age": {
+              "type": "integer",
+              "description": "A idade da segunda pessoa."
+            }
+          },
+          "required": [
+            "person1_age",
+            "person2_age"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_rectangle_area",
+        "description": "Calcule a área de um retângulo com base em suas dimensões.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "width": {
+              "type": "number",
+              "description": "A largura do retângulo."
+            },
+            "height": {
+              "type": "number",
+              "description": "A altura do retângulo."
+            }
+          },
+          "required": [
+            "width",
+            "height"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para um destinatário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient": {
+              "type": "string",
+              "description": "O destinatário do email."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "message": {
+              "type": "string",
+              "description": "A mensagem de email."
+            }
+          },
+          "required": [
+            "recipient",
+            "subject",
+            "message"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_carbon_footprint",
+        "description": "Calcule a pegada de carbono com base em vários fatores.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "mileage": {
+              "type": "number",
+              "description": "A milhagem de um veículo."
+            },
+            "fuel_type": {
+              "type": "string",
+              "description": "O tipo de combustível usado."
+            },
+            "electricity_usage": {
+              "type": "number",
+              "description": "O uso de eletricidade em quilowatt-hora."
+            }
+          },
+          "required": [
+            "mileage",
+            "fuel_type",
+            "electricity_usage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em critérios especificados.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            },
+            "actor": {
+              "type": "string",
+              "description": "O nome do ator no filme."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_random_number",
+        "description": "Gerar um número aleatório dentro de um intervalo especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "min": {
+              "type": "integer",
+              "description": "O valor mínimo do intervalo."
+            },
+            "max": {
+              "type": "integer",
+              "description": "O valor máximo do intervalo."
+            }
+          },
+          "required": [
+            "min",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news",
+        "description": "Obtenha as manchetes das últimas notícias.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de notícias (por exemplo, esportes, política)."
+            }
+          },
+          "required": [
+            "category"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro baseado em título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_events",
+        "description": "Procure eventos com base na localização e data.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "A localização do evento."
+            },
+            "date": {
+              "type": "string",
+              "description": "A data do evento."
+            }
+          },
+          "required": [
+            "location",
+            "date"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_lyrics",
+        "description": "Obtenha a letra de uma música.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "song_title": {
+              "type": "string",
+              "description": "O título da música."
+            },
+            "artist": {
+              "type": "string",
+              "description": "O artista da música."
+            }
+          },
+          "required": [
+            "song_title",
+            "artist"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discount",
+        "description": "Calcule o preço com desconto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original do item."
+            },
+            "discount_percentage": {
+              "type": "number",
+              "description": "A porcentagem de desconto."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "find_nearby_restaurants",
+        "description": "Encontre restaurantes próximos.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "latitude": {
+              "type": "number",
+              "description": "A latitude da localização."
+            },
+            "longitude": {
+              "type": "number",
+              "description": "A longitude da localização."
+            },
+            "radius": {
+              "type": "integer",
+              "description": "O raio de pesquisa em metros."
+            }
+          },
+          "required": [
+            "latitude",
+            "longitude",
+            "radius"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave para procurar"
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "date_of_birth": {
+              "type": "string",
+              "description": "A data de nascimento em formato AAAA-MM-DD"
+            }
+          },
+          "required": [
+            "date_of_birth"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "message": {
+              "type": "string",
+              "description": "O conteúdo do email."
+            }
+          },
+          "required": [
+            "recipient",
+            "subject",
+            "message"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_wikipedia",
+        "description": "Procure um tópico específico na Wikipedia.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "topic": {
+              "type": "string",
+              "description": "O tópico a ser pesquisado."
+            }
+          },
+          "required": [
+            "topic"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em critérios específicos.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discount",
+        "description": "Calcule o preço com desconto para um determinado item.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original do item."
+            },
+            "discount_percentage": {
+              "type": "number",
+              "description": "A porcentagem de desconto a ser aplicada."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_images",
+        "description": "Pesquise imagens com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave para pesquisa de imagem."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_info",
+        "description": "Obtenha informações sobre um filme.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas nos títulos de livros."
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor para filtrar os livros."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da dica para uma fatura.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_amount": {
+              "type": "number",
+              "description": "O valor total da fatura."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem de ponta a ser aplicada."
+            }
+          },
+          "required": [
+            "bill_amount",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movie",
+        "description": "Procure um filme usando seu título.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "movie_title": {
+              "type": "string",
+              "description": "O título do filme."
+            }
+          },
+          "required": [
+            "movie_title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_definition",
+        "description": "Obtenha a definição de uma palavra específica.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra para obter a definição."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para um destinatário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient_email": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "message": {
+              "type": "string",
+              "description": "O conteúdo do email."
+            }
+          },
+          "required": [
+            "recipient_email",
+            "subject",
+            "message"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou ISBN.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar."
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_recipes",
+        "description": "Procure receitas com base em ingredientes.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "ingredients": {
+              "type": "array",
+              "description": "Os ingredientes para procurar."
+            },
+            "diet": {
+              "type": "string",
+              "description": "A restrição alimentar a considerar, p. vegetariano."
+            }
+          },
+          "required": [
+            "ingredients"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da gorjeta com base no total da fatura e na porcentagem de gorjeta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_total": {
+              "type": "number",
+              "description": "O valor total da conta."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem da conta de girar."
+            }
+          },
+          "required": [
+            "bill_total",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_stock_price",
+        "description": "Obtenha o preço atual das ações.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "stock_symbol": {
+              "type": "string",
+              "description": "O símbolo do estoque."
+            }
+          },
+          "required": [
+            "stock_symbol"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "analyze_sentiment",
+        "description": "Analise o sentimento de um texto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto para analisar."
+            }
+          },
+          "required": [
+            "text"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "play_music",
+        "description": "Tocar música.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "song": {
+              "type": "string",
+              "description": "O nome da música a ser tocado."
+            }
+          },
+          "required": [
+            "song"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa para livros."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Pesquise livros com base nas preferências do usuário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            },
+            "language": {
+              "type": "string",
+              "description": "A linguagem do livro."
+            }
+          },
+          "required": [
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_music",
+        "description": "Procure música baseada em artista ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "artist": {
+              "type": "string",
+              "description": "O artista da música."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero da música."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento da música."
+            }
+          },
+          "required": [
+            "artist",
+            "year"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro baseado no título, autor ou ISBN.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduzir o texto de um idioma para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser traduzido."
+            },
+            "source_language": {
+              "type": "string",
+              "description": "A linguagem de origem do texto."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para tradução."
+            }
+          },
+          "required": [
+            "text",
+            "source_language",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em parâmetros.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Obtenha detalhes de um filme.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base no título ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa para filmes."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_distance",
+        "description": "Calcule a distância entre dois locais.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "origin": {
+              "type": "string",
+              "description": "O local inicial."
+            },
+            "destination": {
+              "type": "string",
+              "description": "O local de destino."
+            }
+          },
+          "required": [
+            "origin",
+            "destination"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "play_music",
+        "description": "Tocar música baseada em artista, álbum ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "artist": {
+              "type": "string",
+              "description": "O artista da música."
+            },
+            "album": {
+              "type": "string",
+              "description": "O álbum da música."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero da música."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "search_query": {
+              "type": "string",
+              "description": "O título ou autor do livro."
+            }
+          },
+          "required": [
+            "search_query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa"
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros por título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa"
+            },
+            "search_by": {
+              "type": "string",
+              "description": "O campo para pesquisar"
+            }
+          },
+          "required": [
+            "query",
+            "search_by"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_area",
+        "description": "Calcule a área de uma forma.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "shape": {
+              "type": "string",
+              "description": "A forma para calcular a área"
+            },
+            "dimensions": {
+              "type": "array",
+              "description": "As dimensões da forma"
+            }
+          },
+          "required": [
+            "shape",
+            "dimensions"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base no título ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_todo_list",
+        "description": "Crie uma nova lista de TODO.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "list_name": {
+              "type": "string",
+              "description": "O nome da lista de TODO."
+            }
+          },
+          "required": [
+            "list_name"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_flight_status",
+        "description": "Obtenha o status de um voo.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "flight_number": {
+              "type": "string",
+              "description": "O número do voo."
+            },
+            "date": {
+              "type": "string",
+              "description": "A data do voo."
+            }
+          },
+          "required": [
+            "flight_number",
+            "date"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "genre": {
+              "type": "string",
+              "description": "O gênero dos filmes a serem pesquisados."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento dos filmes."
+            },
+            "rating": {
+              "type": "number",
+              "description": "A classificação mínima dos filmes."
+            }
+          },
+          "required": [
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_note",
+        "description": "Crie uma nova nota.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título da nota."
+            },
+            "content": {
+              "type": "string",
+              "description": "O conteúdo da nota."
+            }
+          },
+          "required": [
+            "title",
+            "content"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_todo",
+        "description": "Crie um novo item de TODO.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "task": {
+              "type": "string",
+              "description": "A descrição da tarefa."
+            },
+            "due_date": {
+              "type": "string",
+              "description": "A data de vencimento da tarefa."
+            }
+          },
+          "required": [
+            "task"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_password",
+        "description": "Gerar uma senha aleatória.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "length": {
+              "type": "integer",
+              "description": "A duração da senha."
+            },
+            "include_special_characters": {
+              "type": "boolean",
+              "description": "Inclua caracteres especiais na senha."
+            }
+          },
+          "required": [
+            "length"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title",
+            "author"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "category": {
+              "type": "string",
+              "description": "A categoria de livros para pesquisar."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros para procurar."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movie",
+        "description": "Procure um filme por título.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_distance",
+        "description": "Calcule a distância entre dois locais.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "origin": {
+              "type": "string",
+              "description": "A localização da origem."
+            },
+            "destination": {
+              "type": "string",
+              "description": "O local de destino."
+            }
+          },
+          "required": [
+            "origin",
+            "destination"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter uma moeda para outra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor para converter."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_random_number",
+        "description": "Gerar um número aleatório dentro de um determinado intervalo.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "min_value": {
+              "type": "number",
+              "description": "O valor mínimo do intervalo."
+            },
+            "max_value": {
+              "type": "number",
+              "description": "O valor máximo do intervalo."
+            }
+          },
+          "required": [
+            "min_value",
+            "max_value"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movie",
+        "description": "Procure um filme.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano do lançamento do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro baseado no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title",
+            "author",
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "check_website_availability",
+        "description": "Verifique a disponibilidade de um site.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "website": {
+              "type": "string",
+              "description": "O URL do site para verificar."
+            }
+          },
+          "required": [
+            "website"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_task",
+        "description": "Crie uma tarefa em uma lista de tarefas.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título da tarefa."
+            },
+            "due_date": {
+              "type": "string",
+              "description": "A data de vencimento da tarefa."
+            },
+            "priority": {
+              "type": "string",
+              "description": "O nível de prioridade da tarefa."
+            }
+          },
+          "required": [
+            "title",
+            "due_date",
+            "priority"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip_amount",
+        "description": "Calcule o valor da ponta com base no total da fatura e na porcentagem de gorjeta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_total": {
+              "type": "number",
+              "description": "O valor total da conta."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem da ponta."
+            }
+          },
+          "required": [
+            "bill_total",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o IMC (índice de massa corporal).",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "type": "number",
+              "description": "O peso da pessoa em quilogramas."
+            },
+            "height": {
+              "type": "number",
+              "description": "A altura da pessoa em metros."
+            }
+          },
+          "required": [
+            "weight",
+            "height"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduzir o texto de um idioma para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto para traduzir."
+            },
+            "source_language": {
+              "type": "string",
+              "description": "A linguagem de origem do texto."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para traduzir o texto."
+            }
+          },
+          "required": [
+            "text",
+            "source_language",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "O título ou o nome do autor para pesquisar."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro baseado em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "string",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter moeda de um tipo para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor a ser convertido."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "schedule_meeting",
+        "description": "Programe uma reunião com participantes e tempo.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "participants": {
+              "type": "array",
+              "description": "Os participantes da reunião."
+            },
+            "time": {
+              "type": "string",
+              "description": "A hora da reunião."
+            }
+          },
+          "required": [
+            "participants",
+            "time"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_random_number",
+        "description": "Gerar um número aleatório dentro de um intervalo especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "min": {
+              "type": "integer",
+              "description": "O valor mínimo para o número aleatório."
+            },
+            "max": {
+              "type": "integer",
+              "description": "O valor máximo para o número aleatório."
+            }
+          },
+          "required": [
+            "min",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "string",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_note",
+        "description": "Crie uma nova nota.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título da nota."
+            },
+            "content": {
+              "type": "string",
+              "description": "O conteúdo da nota."
+            },
+            "category": {
+              "type": "string",
+              "description": "A categoria da nota."
+            }
+          },
+          "required": [
+            "title",
+            "content"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_recipe",
+        "description": "Procure uma receita por ingredientes.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "ingredients": {
+              "type": "array",
+              "description": "Os ingredientes para procurar."
+            }
+          },
+          "required": [
+            "ingredients"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news",
+        "description": "Obtenha as últimas notícias com base na categoria selecionada.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de notícias."
+            }
+          },
+          "required": [
+            "category"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da ponta com base no total da conta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_total": {
+              "type": "number",
+              "description": "O valor total da conta."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem de ponta a ser dada."
+            }
+          },
+          "required": [
+            "bill_total",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_stock_price",
+        "description": "Obtenha o preço atual das ações.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "symbol": {
+              "type": "string",
+              "description": "O símbolo do ticker do estoque."
+            }
+          },
+          "required": [
+            "symbol"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discounted_price",
+        "description": "Calcule o preço com desconto de um produto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original do produto."
+            },
+            "discount_percentage": {
+              "type": "number",
+              "description": "A porcentagem de desconto."
+            },
+            "tax_rate": {
+              "type": "number",
+              "description": "A taxa de imposto aplicada ao produto."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em uma determinada palavra -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar"
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base no título ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "O título ou gênero a procurar."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduza um texto de um idioma para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser traduzido."
+            },
+            "source_language": {
+              "type": "string",
+              "description": "A linguagem de origem do texto."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para a tradução."
+            }
+          },
+          "required": [
+            "text",
+            "source_language",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_images",
+        "description": "Procure imagens com base em uma consulta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "O número máximo de imagens para recuperar."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_dictionary",
+        "description": "Procure o significado de uma palavra no dicionário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra a serem pesquisada no dicionário."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes baseados no título, ator ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "search_query": {
+              "type": "string",
+              "description": "A consulta de pesquisa (título, ator ou gênero)."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento dos filmes."
+            },
+            "rating": {
+              "type": "number",
+              "description": "A classificação mínima dos filmes."
+            }
+          },
+          "required": [
+            "search_query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_random_number",
+        "description": "Gerar um número aleatório dentro de um intervalo especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "min": {
+              "type": "number",
+              "description": "O valor mínimo do intervalo."
+            },
+            "max": {
+              "type": "number",
+              "description": "O valor máximo do intervalo."
+            }
+          },
+          "required": [
+            "min",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduzir o texto de um idioma para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser traduzido."
+            },
+            "source_language": {
+              "type": "string",
+              "description": "A linguagem de origem do texto."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para traduzir o texto."
+            }
+          },
+          "required": [
+            "text",
+            "source_language",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_music",
+        "description": "Procure música baseada em artista ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "artist": {
+              "type": "string",
+              "description": "O nome do artista."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero da música."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento da música."
+            }
+          },
+          "required": [
+            "artist",
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_stock_price",
+        "description": "Obtenha o preço atual das ações de uma empresa.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "company": {
+              "type": "string",
+              "description": "O nome da empresa."
+            }
+          },
+          "required": [
+            "company"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_password",
+        "description": "Gerar uma senha aleatória com critérios especificados.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "length": {
+              "type": "integer",
+              "description": "A duração da senha."
+            },
+            "include_symbols": {
+              "type": "boolean",
+              "description": "Inclua símbolos na senha."
+            },
+            "include_numbers": {
+              "type": "boolean",
+              "description": "Inclua números na senha."
+            }
+          },
+          "required": [
+            "length"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em critérios especificados.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "genre": {
+              "type": "string",
+              "description": "O gênero dos filmes a serem pesquisados."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento dos filmes."
+            },
+            "rating": {
+              "type": "number",
+              "description": "A classificação mínima dos filmes."
+            }
+          },
+          "required": [
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da ponta com base no total da fatura e na porcentagem de gorjeta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_total": {
+              "type": "number",
+              "description": "O valor total da conta."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem a ser inclinada."
+            }
+          },
+          "required": [
+            "bill_total",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_definition",
+        "description": "Obtenha a definição de uma palavra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra para obter a definição de."
+            },
+            "language": {
+              "type": "string",
+              "description": "A linguagem da palavra."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base nos critérios fornecidos.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_car_emissions",
+        "description": "Calcule as emissões de carbono de um carro com base no consumo de combustível e na distância percorrida.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "fuel_consumption": {
+              "type": "number",
+              "description": "O consumo de combustível do carro em litros por 100 quilômetros."
+            },
+            "distance": {
+              "type": "number",
+              "description": "A distância percorrida pelo carro em quilômetros."
+            }
+          },
+          "required": [
+            "fuel_consumption",
+            "distance"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "search_query": {
+              "type": "string",
+              "description": "A consulta de pesquisa (título, autor ou gênero)."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "O número máximo de resultados para retornar."
+            }
+          },
+          "required": [
+            "search_query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa para livros."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor para filtrar os resultados."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em critérios específicos.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "Palavras -chave a serem pesquisadas em títulos ou descrições de livros."
+            },
+            "category": {
+              "type": "string",
+              "description": "A categoria de livros para pesquisar."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros para procurar."
+            }
+          },
+          "required": [
+            "keywords",
+            "category",
+            "author"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_average",
+        "description": "Calcule a média de uma lista de números.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "numbers": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "A lista de números."
+            }
+          },
+          "required": [
+            "numbers"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da dica para uma fatura.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_amount": {
+              "type": "number",
+              "description": "O valor total da fatura."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem de ponta a ser dada."
+            }
+          },
+          "required": [
+            "bill_amount",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_task",
+        "description": "Crie uma nova tarefa.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título da tarefa."
+            },
+            "due_date": {
+              "type": "string",
+              "description": "A data de vencimento da tarefa."
+            },
+            "priority": {
+              "type": "string",
+              "description": "A prioridade da tarefa."
+            }
+          },
+          "required": [
+            "title",
+            "due_date"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para um destinatário especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "body": {
+              "type": "string",
+              "description": "O conteúdo corporal do email."
+            }
+          },
+          "required": [
+            "recipient",
+            "subject",
+            "body"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para um destinatário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "body": {
+              "type": "string",
+              "description": "O conteúdo corporal do email."
+            }
+          },
+          "required": [
+            "recipient",
+            "subject",
+            "body"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news_headlines",
+        "description": "Obtenha as manchetes das últimas notícias.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de notícias desejada."
+            },
+            "country": {
+              "type": "string",
+              "description": "O país para manchetes de notícias."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros para procurar."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas nos títulos ou descrições de livros."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes baseados no título e gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            }
+          },
+          "required": [
+            "title",
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tax",
+        "description": "Calcule o valor do imposto com base na renda e taxa de imposto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "income": {
+              "type": "number",
+              "description": "O valor da renda."
+            },
+            "tax_rate": {
+              "type": "number",
+              "description": "A taxa de imposto em porcentagem."
+            }
+          },
+          "required": [
+            "income",
+            "tax_rate"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_translation",
+        "description": "Obtenha a tradução de um determinado texto em um idioma especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser traduzido."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para tradução."
+            }
+          },
+          "required": [
+            "text",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da ponta para um determinado valor da fatura e porcentagem de gorjeta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_amount": {
+              "type": "number",
+              "description": "O valor da fatura em dólares."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem da ponta como decimal."
+            }
+          },
+          "required": [
+            "bill_amount",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title",
+            "author",
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "birthdate": {
+              "type": "string",
+              "description": "A data de nascimento em formato AAAA-MM-DD"
+            }
+          },
+          "required": [
+            "birthdate"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o índice de massa corporal (IMC) com base na altura e peso.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "height": {
+              "type": "number",
+              "description": "A altura em metros."
+            },
+            "weight": {
+              "type": "number",
+              "description": "O peso em quilogramas."
+            }
+          },
+          "required": [
+            "height",
+            "weight"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base no título, gênero ou ano de lançamento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            },
+            "release_year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em uma palavra -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar"
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o IMC (índice de massa corporal).",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "height": {
+              "type": "number",
+              "description": "A altura em metros."
+            },
+            "weight": {
+              "type": "number",
+              "description": "O peso em quilogramas."
+            }
+          },
+          "required": [
+            "height",
+            "weight"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em uma palavra -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar"
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor"
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter um valor de uma moeda para outra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor a ser convertido."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news_headlines",
+        "description": "Obtenha as manchetes das últimas notícias.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de notícias, p. negócios, esportes"
+            }
+          },
+          "required": [
+            "category"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_profit_margin",
+        "description": "Calcule a margem de lucro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "revenue": {
+              "type": "number",
+              "description": "A receita total."
+            },
+            "cost": {
+              "type": "number",
+              "description": "O custo total."
+            }
+          },
+          "required": [
+            "revenue",
+            "cost"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_recipes",
+        "description": "Procure receitas com base em ingredientes.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "ingredients": {
+              "type": "array",
+              "description": "A lista de ingredientes."
+            }
+          },
+          "required": [
+            "ingredients"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_jobs",
+        "description": "Procure empregos com base na localização, indústria ou título.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "A localização do trabalho."
+            },
+            "industry": {
+              "type": "string",
+              "description": "A indústria do trabalho."
+            },
+            "title": {
+              "type": "string",
+              "description": "O cargo."
+            }
+          },
+          "required": [
+            "location"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter uma moeda para outra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor a ser convertido."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_image",
+        "description": "Pesquise imagens relacionadas a uma palavra -chave específica.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar."
+            },
+            "color": {
+              "type": "string",
+              "description": "O filtro de cores para as imagens."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movie",
+        "description": "Procure um filme baseado em título e gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "birthdate": {
+              "type": "string",
+              "description": "A data de nascimento em formato yyyy-mm-dd"
+            }
+          },
+          "required": [
+            "birthdate"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_recipes",
+        "description": "Procure receitas com base em ingredientes.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "ingredients": {
+              "type": "array",
+              "description": "Os ingredientes para procurar."
+            }
+          },
+          "required": [
+            "ingredients"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Obtenha detalhes sobre um filme específico.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para um destinatário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "message": {
+              "type": "string",
+              "description": "O conteúdo do email."
+            }
+          },
+          "required": [
+            "recipient",
+            "subject",
+            "message"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_stock_price",
+        "description": "Obtenha o preço atual das ações de uma empresa.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "symbol": {
+              "type": "string",
+              "description": "O símbolo de estoque."
+            }
+          },
+          "required": [
+            "symbol"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o índice de massa corporal (IMC), dado o peso e a altura.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "type": "number",
+              "description": "O peso em quilogramas."
+            },
+            "height": {
+              "type": "number",
+              "description": "A altura em metros."
+            }
+          },
+          "required": [
+            "weight",
+            "height"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "birthdate": {
+              "type": "string",
+              "description": "A data de nascimento no formato aaaaa-mm-dd"
+            }
+          },
+          "required": [
+            "birthdate"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "check_website_availability",
+        "description": "Verifique se um site está disponível no momento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "website_url": {
+              "type": "string",
+              "description": "O URL do site para verificar."
+            }
+          },
+          "required": [
+            "website_url"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_password",
+        "description": "Gerar uma senha aleatória.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "length": {
+              "type": "integer",
+              "description": "A duração da senha."
+            },
+            "include_symbols": {
+              "type": "boolean",
+              "description": "Inclua símbolos na senha."
+            },
+            "include_numbers": {
+              "type": "boolean",
+              "description": "Inclua números na senha."
+            }
+          },
+          "required": [
+            "length"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "analyze_sentiment",
+        "description": "Analisar o sentimento de um texto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto para analisar."
+            }
+          },
+          "required": [
+            "text"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar no título ou autor do livro."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_images",
+        "description": "Procure imagens.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "Palavras -chave para procurar imagens."
+            },
+            "color": {
+              "type": "string",
+              "description": "A cor das imagens."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "O título ou autor para procurar."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "O título do livro ou autor para procurar."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_random_fact",
+        "description": "Obtenha um fato aleatório de uma categoria específica.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria do fato."
+            }
+          },
+          "required": [
+            "category"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_images",
+        "description": "Pesquise imagens com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "color": {
+              "type": "string",
+              "description": "O filtro de cores para as imagens."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_definition",
+        "description": "Obtenha a definição de uma palavra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra para obter a definição de."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base no título ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero de filmes para pesquisar."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_distance",
+        "description": "Calcule a distância entre dois locais.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "start_location": {
+              "type": "string",
+              "description": "O local inicial."
+            },
+            "end_location": {
+              "type": "string",
+              "description": "A localização final."
+            }
+          },
+          "required": [
+            "start_location",
+            "end_location"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_square_root",
+        "description": "Calcule a raiz quadrada de um número.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "number",
+              "description": "O número para calcular a raiz quadrada de."
+            }
+          },
+          "required": [
+            "number"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para o destinatário especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "recipient": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "message": {
+              "type": "string",
+              "description": "O conteúdo do email."
+            }
+          },
+          "required": [
+            "recipient",
+            "subject",
+            "message"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "send_email",
+        "description": "Envie um email para um destinatário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "to": {
+              "type": "string",
+              "description": "O endereço de e -mail do destinatário."
+            },
+            "subject": {
+              "type": "string",
+              "description": "O assunto do email."
+            },
+            "body": {
+              "type": "string",
+              "description": "O corpo do email."
+            }
+          },
+          "required": [
+            "to",
+            "subject",
+            "body"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da dica para uma fatura.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_amount": {
+              "type": "number",
+              "description": "O valor da fatura."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem de ponta."
+            }
+          },
+          "required": [
+            "bill_amount",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news",
+        "description": "Obtenha as últimas notícias.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de notícias para recuperar."
+            }
+          },
+          "required": [
+            "category"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa (título ou autor)."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "O número máximo de resultados para retornar."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa para livros."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discount",
+        "description": "Calcule o valor do desconto com base na porcentagem de preço e desconto original.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original do item."
+            },
+            "discount_percentage": {
+              "type": "number",
+              "description": "A porcentagem de desconto."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news_headlines",
+        "description": "Obtenha as manchetes das últimas notícias.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de notícias (por exemplo, esportes, política, entretenimento)."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "check_email_availability",
+        "description": "Verifique a disponibilidade de um endereço de e -mail.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "description": "O endereço de e -mail para verificar."
+            }
+          },
+          "required": [
+            "email"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa"
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro"
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro"
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "make_note",
+        "description": "Fazer uma anotação.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título da nota."
+            },
+            "content": {
+              "type": "string",
+              "description": "O conteúdo da nota."
+            }
+          },
+          "required": [
+            "title",
+            "content"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Obtenha detalhes de um filme como título, ano de lançamento e elenco.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "movie_id": {
+              "type": "string",
+              "description": "O identificador único do filme."
+            }
+          },
+          "required": [
+            "movie_id"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base nos critérios especificados.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "title",
+            "author"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_temperature",
+        "description": "Converter a temperatura de uma unidade para outra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "temperature": {
+              "type": "number",
+              "description": "O valor da temperatura."
+            },
+            "from_unit": {
+              "type": "string",
+              "description": "A unidade de temperatura para converter de."
+            },
+            "to_unit": {
+              "type": "string",
+              "description": "A unidade de temperatura para se converter."
+            }
+          },
+          "required": [
+            "temperature",
+            "from_unit",
+            "to_unit"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_song_lyrics",
+        "description": "Obtenha a letra de uma música específica.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "song_title": {
+              "type": "string",
+              "description": "O título da música."
+            },
+            "artist_name": {
+              "type": "string",
+              "description": "O nome do artista."
+            }
+          },
+          "required": [
+            "song_title",
+            "artist_name"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_news",
+        "description": "Pesquise artigos de notícias com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas nos artigos de notícias."
+            },
+            "max_results": {
+              "type": "integer",
+              "description": "O número máximo de resultados para retornar."
+            }
+          },
+          "required": [
+            "keywords",
+            "max_results"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "search_query": {
+              "type": "string",
+              "description": "O título ou autor para procurar."
+            }
+          },
+          "required": [
+            "search_query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_images",
+        "description": "Pesquise imagens com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "limit": {
+              "type": "integer",
+              "description": "O número máximo de imagens para recuperar."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou palavra -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa (título, autor ou palavra -chave)."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero de livro preferido."
+            },
+            "language": {
+              "type": "string",
+              "description": "A linguagem do livro preferida."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tax",
+        "description": "Calcule o valor do imposto para uma determinada renda.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "income": {
+              "type": "number",
+              "description": "O valor da renda."
+            },
+            "tax_rate": {
+              "type": "number",
+              "description": "A taxa de imposto como uma porcentagem."
+            }
+          },
+          "required": [
+            "income",
+            "tax_rate"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_stock_price",
+        "description": "Obtenha o preço atual das ações.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "symbol": {
+              "type": "string",
+              "description": "O símbolo de estoque."
+            }
+          },
+          "required": [
+            "symbol"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduzir texto para outro idioma.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto para traduzir."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para tradução."
+            }
+          },
+          "required": [
+            "text",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em critérios especificados.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "actor": {
+              "type": "string",
+              "description": "O ator do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            }
+          },
+          "required": [
+            "title",
+            "actor"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em uma consulta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa para livros."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros para procurar."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero dos livros a serem procurados."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_units",
+        "description": "Converter unidades de um sistema para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "number",
+              "description": "O valor a ser convertido."
+            },
+            "from_unit": {
+              "type": "string",
+              "description": "A unidade de medição para converter de."
+            },
+            "to_unit": {
+              "type": "string",
+              "description": "A unidade de medição para converter."
+            }
+          },
+          "required": [
+            "value",
+            "from_unit",
+            "to_unit"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter moeda de um tipo para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor para converter."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_distance",
+        "description": "Calcule a distância entre dois locais.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "source": {
+              "type": "string",
+              "description": "O local da fonte."
+            },
+            "destination": {
+              "type": "string",
+              "description": "O local de destino."
+            }
+          },
+          "required": [
+            "source",
+            "destination"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em um critério especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro usando seu título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "book_title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "book_title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age_in_seconds",
+        "description": "Calcule a idade em segundos com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "date_of_birth": {
+              "type": "string",
+              "description": "A data de nascimento."
+            },
+            "current_date": {
+              "type": "string",
+              "description": "A data atual."
+            }
+          },
+          "required": [
+            "date_of_birth",
+            "current_date"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "analyze_social_media_sentiment",
+        "description": "Analise o sentimento de postagens de mídia social.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "posts": {
+              "type": "array",
+              "description": "As postagens das mídias sociais a serem analisadas."
+            },
+            "platform": {
+              "type": "string",
+              "description": "A plataforma da qual as postagens são coletadas."
+            }
+          },
+          "required": [
+            "posts",
+            "platform"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "create_calendar_event",
+        "description": "Crie um novo evento no calendário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do evento."
+            },
+            "start_time": {
+              "type": "string",
+              "description": "A hora de início do evento."
+            },
+            "end_time": {
+              "type": "string",
+              "description": "O horário final do evento."
+            }
+          },
+          "required": [
+            "title",
+            "start_time",
+            "end_time"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter um valor de uma moeda para outra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "O valor para converter."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro por título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "title",
+            "author",
+            "genre"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movie",
+        "description": "Procure um filme baseado no título.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "check_spelling",
+        "description": "Verifique a ortografia de uma palavra ou frase.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser verificado."
+            },
+            "language": {
+              "type": "string",
+              "description": "A linguagem do texto."
+            }
+          },
+          "required": [
+            "text"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "date_of_birth": {
+              "type": "string",
+              "description": "A data de nascimento no formato: AAAA-MM-DD"
+            }
+          },
+          "required": [
+            "date_of_birth"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa (título, autor ou gênero)."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_definition",
+        "description": "Obtenha a definição de uma palavra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra para obter a definição."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o IMC (índice de massa corporal).",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "type": "number",
+              "description": "Peso do usuário em quilogramas."
+            },
+            "height": {
+              "type": "number",
+              "description": "Altura do usuário em metros."
+            }
+          },
+          "required": [
+            "weight",
+            "height"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "birth_date": {
+              "type": "string",
+              "description": "A data de nascimento em formato aaaaa-dd"
+            }
+          },
+          "required": [
+            "birth_date"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "title",
+            "author"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_invoice",
+        "description": "Gere uma fatura com detalhes especificados.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "customer_name": {
+              "type": "string",
+              "description": "O nome do cliente."
+            },
+            "items": {
+              "type": "array",
+              "description": "Os itens na fatura."
+            },
+            "total_amount": {
+              "type": "number",
+              "description": "O valor total da fatura."
+            }
+          },
+          "required": [
+            "customer_name",
+            "items",
+            "total_amount"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_interest",
+        "description": "Calcule os juros obtidos em um investimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "principal_amount": {
+              "type": "number",
+              "description": "O valor principal do investimento."
+            },
+            "interest_rate": {
+              "type": "number",
+              "description": "A taxa de juros anual."
+            },
+            "time_period": {
+              "type": "integer",
+              "description": "O período de tempo em anos."
+            }
+          },
+          "required": [
+            "principal_amount",
+            "interest_rate",
+            "time_period"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule o valor da ponta com base na porcentagem total da fatura e da gorjeta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "total_bill": {
+              "type": "number",
+              "description": "O valor total da fatura"
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem de ponta"
+            }
+          },
+          "required": [
+            "total_bill",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_definition",
+        "description": "Obtenha a definição de uma palavra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra para a qual a definição é necessária."
+            },
+            "language": {
+              "type": "string",
+              "description": "A linguagem da definição."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_mortgage",
+        "description": "Calcule o pagamento mensal da hipoteca.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "loan_amount": {
+              "type": "number",
+              "description": "O valor do empréstimo."
+            },
+            "interest_rate": {
+              "type": "number",
+              "description": "A taxa de juros anual."
+            },
+            "loan_term": {
+              "type": "integer",
+              "description": "O prazo do empréstimo em anos."
+            }
+          },
+          "required": [
+            "loan_amount",
+            "interest_rate",
+            "loan_term"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa"
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em critérios específicos.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros"
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero dos livros"
+            },
+            "publication_year": {
+              "type": "integer",
+              "description": "O ano de publicação dos livros"
+            }
+          },
+          "required": [
+            "author",
+            "genre",
+            "publication_year"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movie",
+        "description": "Pesquise filmes com base nas preferências do usuário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "play_music",
+        "description": "Toque música de um gênero ou artista específico.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "genre": {
+              "type": "string",
+              "description": "O gênero da música para tocar."
+            },
+            "artist": {
+              "type": "string",
+              "description": "O artista cuja música para tocar."
+            }
+          },
+          "required": [
+            "genre",
+            "artist"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discount",
+        "description": "Calcule o preço com desconto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original."
+            },
+            "discount_percentage": {
+              "type": "number",
+              "description": "A porcentagem de desconto."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduzir o texto de um idioma para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser traduzido."
+            },
+            "source_language": {
+              "type": "string",
+              "description": "A linguagem de origem do texto."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para a tradução."
+            }
+          },
+          "required": [
+            "text",
+            "source_language",
+            "target_language"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes por título ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar filmes."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero para filtrar os filmes."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor preferido."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_product",
+        "description": "Procure um produto com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "string",
+              "description": "As palavras -chave para procurar"
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tip",
+        "description": "Calcule a quantidade da ponta.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "bill_amount": {
+              "type": "number",
+              "description": "O valor total da fatura."
+            },
+            "tip_percentage": {
+              "type": "number",
+              "description": "A porcentagem de ponta."
+            }
+          },
+          "required": [
+            "bill_amount",
+            "tip_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_stock_price",
+        "description": "Obtenha o preço atual das ações.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "stock_symbol": {
+              "type": "string",
+              "description": "O símbolo do estoque, p. AAPL"
+            }
+          },
+          "required": [
+            "stock_symbol"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "check_spelling",
+        "description": "Verifique a ortografia de uma determinada palavra.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "word": {
+              "type": "string",
+              "description": "A palavra para verificar a ortografia de."
+            }
+          },
+          "required": [
+            "word"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "string",
+              "description": "Palavras -chave para procurar livros."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "category": {
+              "type": "string",
+              "description": "A categoria do livro."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base nos critérios fornecidos.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Obtenha detalhes de um filme por id.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "movie_id": {
+              "type": "string",
+              "description": "O ID do filme."
+            }
+          },
+          "required": [
+            "movie_id"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base no título, autor ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "play_music",
+        "description": "Toque música com base nas preferências do usuário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "genre": {
+              "type": "string",
+              "description": "O gênero musical."
+            },
+            "mood": {
+              "type": "string",
+              "description": "O humor do usuário."
+            }
+          },
+          "required": [
+            "genre",
+            "mood"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_age",
+        "description": "Calcule a idade com base na data de nascimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "birth_date": {
+              "type": "string",
+              "description": "A data de nascimento em formato AAAA-MM-DD"
+            }
+          },
+          "required": [
+            "birth_date"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "description": "As palavras -chave a serem procuradas nos livros."
+            },
+            "author": {
+              "type": "string",
+              "description": "O nome do autor."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base em uma palavra -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discounted_price",
+        "description": "Calcule o preço com desconto com base no preço original e no valor do desconto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original do item."
+            },
+            "discount_amount": {
+              "type": "number",
+              "description": "O valor do desconto."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_amount"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes baseados em gênero e ano.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "genre": {
+              "type": "string",
+              "description": "O gênero do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento do filme."
+            }
+          },
+          "required": [
+            "genre",
+            "year"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "convert_currency",
+        "description": "Converter moeda de um tipo para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "amount": {
+              "type": "number",
+              "description": "A quantidade de moeda para converter."
+            },
+            "from_currency": {
+              "type": "string",
+              "description": "A moeda para converter de."
+            },
+            "to_currency": {
+              "type": "string",
+              "description": "A moeda para se converter."
+            }
+          },
+          "required": [
+            "amount",
+            "from_currency",
+            "to_currency"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_random_number",
+        "description": "Gerar um número aleatório dentro de um intervalo especificado.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "min_value": {
+              "type": "number",
+              "description": "O valor mínimo."
+            },
+            "max_value": {
+              "type": "number",
+              "description": "O valor máximo."
+            }
+          },
+          "required": [
+            "min_value",
+            "max_value"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o índice de massa corporal (IMC).",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "weight": {
+              "type": "number",
+              "description": "O peso em quilogramas."
+            },
+            "height": {
+              "type": "number",
+              "description": "A altura em metros."
+            }
+          },
+          "required": [
+            "weight",
+            "height"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "generate_random_quote",
+        "description": "Gerar uma cotação aleatória de uma coleção.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "A categoria de citações."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor da citação."
+            }
+          },
+          "required": []
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Obtenha detalhes sobre um filme.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "movie_title": {
+              "type": "string",
+              "description": "O título do filme."
+            }
+          },
+          "required": [
+            "movie_title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_recipes",
+        "description": "Procure receitas com base em ingredientes.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "ingredients": {
+              "type": "array",
+              "description": "Os ingredientes a serem procurados nas receitas."
+            }
+          },
+          "required": [
+            "ingredients"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_book",
+        "description": "Procure um livro por título ou autor.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "O título ou autor do livro."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_news",
+        "description": "Obtenha as últimas notícias.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "category": {
+              "type": "string",
+              "description": "Categoria de notícias preferidas (por exemplo, esportes, tecnologia, política)."
+            },
+            "country": {
+              "type": "string",
+              "description": "País de notícias preferidas (por exemplo, EUA, Reino Unido, Índia)."
+            }
+          },
+          "required": [
+            "category",
+            "country"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base nas preferências do usuário.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do livro."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_bmi",
+        "description": "Calcule o índice de massa corporal (IMC).",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "height": {
+              "type": "number",
+              "description": "A altura em metros."
+            },
+            "weight": {
+              "type": "number",
+              "description": "O peso em quilogramas."
+            }
+          },
+          "required": [
+            "height",
+            "weight"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "get_movie_details",
+        "description": "Obtenha os detalhes de um filme.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "O título do filme."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano do filme."
+            }
+          },
+          "required": [
+            "title"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_tax",
+        "description": "Calcule o valor do imposto por um determinado preço.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "price": {
+              "type": "number",
+              "description": "O preço."
+            },
+            "tax_rate": {
+              "type": "number",
+              "description": "A taxa de imposto."
+            }
+          },
+          "required": [
+            "price",
+            "tax_rate"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_discount",
+        "description": "Calcule o preço com desconto de um produto.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "original_price": {
+              "type": "number",
+              "description": "O preço original do produto."
+            },
+            "discount_percentage": {
+              "type": "number",
+              "description": "A porcentagem de desconto a ser aplicada."
+            }
+          },
+          "required": [
+            "original_price",
+            "discount_percentage"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_music",
+        "description": "Pesquise álbuns ou músicas de música.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "A consulta de pesquisa por música."
+            },
+            "artist": {
+              "type": "string",
+              "description": "O nome do artista."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_movies",
+        "description": "Pesquise filmes com base no título ou gênero.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keyword": {
+              "type": "string",
+              "description": "A palavra -chave a procurar nos filmes."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero a procurar."
+            },
+            "year": {
+              "type": "integer",
+              "description": "O ano de lançamento para filtrar."
+            }
+          },
+          "required": [
+            "keyword"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Procure livros com base em determinados critérios.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "string",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor do livro."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero do livro."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_future_value",
+        "description": "Calcule o valor futuro de um investimento.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "principal": {
+              "type": "number",
+              "description": "O valor inicial do investimento."
+            },
+            "interest_rate": {
+              "type": "number",
+              "description": "A taxa de juros anual."
+            },
+            "years": {
+              "type": "integer",
+              "description": "O número de anos em que o investimento é realizado."
+            }
+          },
+          "required": [
+            "principal",
+            "interest_rate",
+            "years"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "calculate_distance",
+        "description": "Calcule a distância entre dois locais.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "location1": {
+              "type": "string",
+              "description": "O primeiro local."
+            },
+            "location2": {
+              "type": "string",
+              "description": "O segundo local."
+            }
+          },
+          "required": [
+            "location1",
+            "location2"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "search_books",
+        "description": "Pesquise livros com base em palavras -chave.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "string",
+              "description": "As palavras -chave a serem pesquisadas."
+            },
+            "author": {
+              "type": "string",
+              "description": "O autor dos livros."
+            },
+            "genre": {
+              "type": "string",
+              "description": "O gênero dos livros."
+            }
+          },
+          "required": [
+            "keywords"
+          ]
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "translate_text",
+        "description": "Traduza um texto de um idioma para outro.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "O texto a ser traduzido."
+            },
+            "source_language": {
+              "type": "string",
+              "description": "A linguagem original do texto."
+            },
+            "target_language": {
+              "type": "string",
+              "description": "O idioma de destino para tradução."
+            }
+          },
+          "required": [
+            "text",
+            "source_language",
+            "target_language"
+          ]
+        }
+      }
+    }
+  ],
+  "examples": [
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"source\": {\"type\": \"string\", \"description\": \"O local da fonte.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"source\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova Iorque e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"source\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"source\": {\"type\": \"string\", \"description\": \"O local da fonte.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"source\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"source\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_interest\", \"description\": \"Calcule os juros obtidos em um investimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"principal_amount\": {\"type\": \"number\", \"description\": \"O valor principal do investimento.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual.\"}, \"time_period\": {\"type\": \"integer\", \"description\": \"O período de tempo em anos.\"}}, \"required\": [\"principal_amount\", \"interest_rate\", \"time_period\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu tenho um investimento de $5000 com uma taxa de juros anual de 5%. Eu quero saber quanto de juros eu ganharei em 3 anos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_interest\", \"arguments\": {\"principal_amount\": 5000, \"interest_rate\": 5, \"time_period\": 3}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_interest"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"A localização da origem.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_fibonacci_sequence\", \"description\": \"Calcule a sequência de Fibonacci até um determinado número.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"number\": {\"type\": \"integer\", \"description\": \"O número para calcular a sequência de Fibonacci até.\"}}, \"required\": [\"number\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance",
+        "calculate_fibonacci_sequence"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da gorjeta com base no total da fatura e na porcentagem de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_total\": {\"type\": \"number\", \"description\": \"O valor total da conta.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem da conta de girar.\"}}, \"required\": [\"bill_total\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. O valor total é de $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_total\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"start_location\": {\"type\": \"string\", \"description\": \"O local inicial.\"}, \"end_location\": {\"type\": \"string\", \"description\": \"A localização final.\"}}, \"required\": [\"start_location\", \"end_location\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"start_location\": \"New York\", \"end_location\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes de um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me falar sobre o filme \"A Origem\"?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"title\": \"Inception\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi um vestido que eu gostei. Ele tinha um preço original de $200, mas está com 20% de desconto. Você pode me dizer quanto vai custar agora?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"Os ingredientes a serem procurados nas receitas.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu tenho frango, brócolis e queijo. O que posso fazer com isso?",
+      "completion": "<tool_call>\n{\"name\": \"search_recipes\", \"arguments\": {\"ingredients\": [\"chicken\", \"broccoli\", \"cheese\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_recipes"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes sobre um filme específico.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me contar sobre o filme \"A Origem\"?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"title\": \"Inception\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para traduzir.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"O código da linguagem de origem.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O código de idioma de destino.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_loan_payment\", \"description\": \"Calcule o pagamento mensal do empréstimo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"loan_amount\": {\"type\": \"integer\", \"description\": \"O valor do empréstimo.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros para o empréstimo.\"}, \"loan_term\": {\"type\": \"integer\", \"description\": \"A duração do empréstimo em anos.\"}}, \"required\": [\"loan_amount\", \"interest_rate\", \"loan_term\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu tenho uma frase em francês que preciso traduzir para o inglês. A frase é \"Je suis très heureux de vous rencontrer\".",
+      "completion": "<tool_call>\n{\"name\": \"translate_text\", \"arguments\": {\"text\": \"Je suis très heureux de vous rencontrer\", \"source_language\": \"fr\", \"target_language\": \"en\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "translate_text",
+        "calculate_loan_payment"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule a quantidade da ponta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_password\", \"description\": \"Gerar uma senha aleatória.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. O valor total da conta é $50 e eu quero deixar uma gorjeta de 20%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 50, \"tip_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip",
+        "generate_random_password"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto em porcentagem.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_song\", \"description\": \"Procure uma música por título ou artista.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para músicas.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi um vestido que gostei. Ele tinha o preço original de $100, mas está com um desconto de 20%. Você pode me dizer quanto custará após o desconto?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 100, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount",
+        "search_song"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes de um filme como título, ano de lançamento e elenco.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"movie_id\": {\"type\": \"string\", \"description\": \"O identificador único do filme.\"}}, \"required\": [\"movie_id\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me contar mais sobre o filme com o id 'tt0111161'?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"movie_id\": \"tt0111161\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_square_root\", \"description\": \"Calcule a raiz quadrada de um número.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"number\": {\"type\": \"number\", \"description\": \"O número para calcular a raiz quadrada de.\"}}, \"required\": [\"number\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso encontrar a raiz quadrada de 81. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_square_root\", \"arguments\": {\"number\": 81}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_square_root"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 USD para EUR. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_invoice\", \"description\": \"Gere uma fatura com detalhes especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"customer_name\": {\"type\": \"string\", \"description\": \"O nome do cliente.\"}, \"items\": {\"type\": \"array\", \"description\": \"Os itens na fatura.\"}, \"total_amount\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}}, \"required\": [\"customer_name\", \"items\", \"total_amount\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso gerar uma fatura para um cliente chamado John Doe. Os itens são um laptop, um mouse e um teclado. O valor total é $1500.",
+      "completion": "<tool_call>\n{\"name\": \"generate_invoice\", \"arguments\": {\"customer_name\": \"John Doe\", \"items\": [\"laptop\", \"mouse\", \"keyboard\"], \"total_amount\": 1500}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_invoice"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes de um filme por id.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"movie_id\": {\"type\": \"string\", \"description\": \"O ID do filme.\"}}, \"required\": [\"movie_id\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me contar sobre o filme com o ID 'tt0111161'?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"movie_id\": \"tt0111161\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso da pessoa em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura da pessoa em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birth_date\": {\"type\": \"string\", \"description\": \"A data de nascimento da pessoa (AAAA-MM-DD).\"}}, \"required\": [\"birth_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu gostaria de calcular meu IMC. Eu peso 70 quilos e minha altura é de 1,75 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi",
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi um vestido que gostei. Ele estava originalmente precificado em $200, mas está com 20% de desconto. Quanto custará agora?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule a quantidade da ponta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O valor da minha conta é $85 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 85, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_word_definitions\", \"description\": \"Obtenha definições de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter definições.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem da palavra.\"}}, \"required\": [\"word\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"description\": \"Os ingredientes para procurar.\"}, \"cuisine\": {\"type\": \"string\", \"description\": \"O tipo de cozinha para filtrar as receitas.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me dizer a definição da palavra 'serendipidade'?",
+      "completion": "<tool_call>\n{\"name\": \"get_word_definitions\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_word_definitions",
+        "search_recipes"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"A localização da origem.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_mortgage_payments\", \"description\": \"Calcule os pagamentos mensais de hipoteca.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"loan_amount\": {\"type\": \"number\", \"description\": \"O valor do empréstimo.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual.\"}, \"loan_term\": {\"type\": \"integer\", \"description\": \"O prazo do empréstimo em anos.\"}}, \"required\": [\"loan_amount\", \"interest_rate\", \"loan_term\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_report\", \"description\": \"Gerar um relatório com base nos dados especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"data\": {\"type\": \"array\", \"description\": \"Os dados a serem incluídos no relatório.\"}, \"report_type\": {\"type\": \"string\", \"description\": \"O tipo de relatório para gerar.\"}}, \"required\": [\"data\", \"report_type\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular meus pagamentos mensais da hipoteca. Eu tenho um valor de empréstimo de $200.000 com uma taxa de juros anual de 3,5% e um prazo de empréstimo de 30 anos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_mortgage_payments\", \"arguments\": {\"loan_amount\": 200000, \"interest_rate\": 3.5, \"loan_term\": 30}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_mortgage_payments",
+        "generate_report"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"Os ingredientes para procurar.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu tenho um pouco de frango, brócolis e queijo. O que posso fazer com isso?",
+      "completion": "<tool_call>\n{\"name\": \"search_recipes\", \"arguments\": {\"ingredients\": [\"chicken\", \"broccoli\", \"cheese\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_recipes"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da dica para uma fatura.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. O valor total é de $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_username\", \"description\": \"Gerar um nome de usuário único.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"name\": {\"type\": \"string\", \"description\": \"O nome para gerar nome de usuário.\"}}, \"required\": [\"name\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"create_account\", \"description\": \"Crie uma nova conta de usuário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"username\": {\"type\": \"string\", \"description\": \"O nome de usuário para a conta.\"}, \"password\": {\"type\": \"string\", \"description\": \"A senha da conta.\"}, \"email\": {\"type\": \"string\", \"description\": \"O endereço de e -mail da conta.\"}}, \"required\": [\"username\", \"password\", \"email\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de um nome de usuário único para minha nova conta. Meu nome é John Doe.",
+      "completion": "<tool_call>\n{\"name\": \"generate_username\", \"arguments\": {\"name\": \"John Doe\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_username",
+        "create_account"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base no total da fatura e na porcentagem de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_total\": {\"type\": \"number\", \"description\": \"O valor total da conta.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem a ser inclinada.\"}}, \"required\": [\"bill_total\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O total da minha conta é R$ 85 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_total\": 85, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_restaurants\", \"description\": \"Procure restaurantes baseados na localização e cozinha.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"O local para procurar restaurantes.\"}, \"cuisine\": {\"type\": \"string\", \"description\": \"O tipo de cozinha para filtrar os restaurantes.\"}}, \"required\": [\"location\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"items\": {\"type\": \"string\"}, \"description\": \"Os ingredientes para procurar.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou em Nova York e estou com vontade de comer comida italiana. Você pode me ajudar a encontrar um restaurante?",
+      "completion": "<tool_call>\n{\"name\": \"search_restaurants\", \"arguments\": {\"location\": \"New York\", \"cuisine\": \"Italian\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_restaurants",
+        "search_recipes"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"stock_symbol\": {\"type\": \"string\", \"description\": \"O símbolo do estoque, p. AAPL\"}}, \"required\": [\"stock_symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"stock_symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birth_date\": {\"type\": \"string\", \"description\": \"A data de nascimento.\"}}, \"required\": [\"birth_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou procurando um filme, mas não consigo lembrar o título completo. Tinha a palavra \"estrela\" nele.",
+      "completion": "<tool_call>\n{\"name\": \"search_movies\", \"arguments\": {\"title\": \"star\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_movies",
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Recupere detalhes sobre um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"movie_title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"movie_title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me contar sobre o filme \"A Origem\"?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"movie_title\": \"Inception\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_units\", \"description\": \"Converter unidades de um sistema para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"value\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_unit\": {\"type\": \"string\", \"description\": \"A unidade de medição para converter de.\"}, \"to_unit\": {\"type\": \"string\", \"description\": \"A unidade de medição para converter.\"}}, \"required\": [\"value\", \"from_unit\", \"to_unit\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 50 milhas em quilômetros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_units\", \"arguments\": {\"value\": 50, \"from_unit\": \"miles\", \"to_unit\": \"kilometers\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_units"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC) com base na altura e peso.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"height\": {\"type\": \"number\", \"description\": \"A altura em centímetros\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas\"}}, \"required\": [\"height\", \"weight\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"convert_temperature\", \"description\": \"Converter a temperatura de uma unidade para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"temperature\": {\"type\": \"number\", \"description\": \"O valor da temperatura\"}, \"from\": {\"type\": \"string\", \"description\": \"A unidade de temperatura atual\"}, \"to\": {\"type\": \"string\", \"description\": \"A unidade de temperatura desejada\"}}, \"required\": [\"temperature\", \"from\", \"to\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Eu tenho 180 cm de altura e peso 75 kg.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"height\": 180, \"weight\": 75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi",
+        "convert_temperature"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da dica para uma fatura.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta a ser dada.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O valor da minha conta é $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip_amount\", \"description\": \"Calcule o valor da ponta com base no total da fatura e na porcentagem de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_total\": {\"type\": \"number\", \"description\": \"O valor total da conta.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem da ponta.\"}}, \"required\": [\"bill_total\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. O valor total é $50 e eu quero deixar uma gorjeta de 20%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip_amount\", \"arguments\": {\"bill_total\": 50, \"tip_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip_amount"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_news\", \"description\": \"Procure artigos de notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"sources\": {\"type\": \"array\", \"description\": \"As fontes de notícias para pesquisar.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem dos artigos de notícias.\"}}, \"required\": [\"query\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de um tipo para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"A quantidade de dinheiro para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"O tipo de moeda atual.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"O tipo de moeda desejado para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu quero saber as últimas notícias sobre o Rover de Marte.",
+      "completion": "<tool_call>\n{\"name\": \"search_news\", \"arguments\": {\"query\": \"Mars Rover\", \"sources\": [\"NASA\", \"Space.com\"], \"language\": \"English\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_news",
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base no total da fatura e na porcentagem de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_total\": {\"type\": \"number\", \"description\": \"O valor total da conta.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta a ser dada.\"}}, \"required\": [\"bill_total\", \"tip_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD.\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O total da minha conta é $85 e eu quero deixar uma gorjeta de 15%. Quanto isso seria?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_total\": 85, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip",
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de um para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"from\": {\"type\": \"string\", \"description\": \"O código da moeda para converter de.\"}, \"to\": {\"type\": \"string\", \"description\": \"O código da moeda para se converter.\"}, \"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}}, \"required\": [\"from\", \"to\", \"amount\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"get_song_lyrics\", \"description\": \"Obtenha a letra de uma música específica.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da música.\"}, \"artist\": {\"type\": \"string\", \"description\": \"O artista da música.\"}}, \"required\": [\"title\", \"artist\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 USD para EUR. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"from\": \"USD\", \"to\": \"EUR\", \"amount\": 1000}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency",
+        "get_song_lyrics"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_future_value\", \"description\": \"Calcule o valor futuro de um investimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"principal\": {\"type\": \"number\", \"description\": \"O valor inicial do investimento.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual.\"}, \"years\": {\"type\": \"integer\", \"description\": \"O número de anos em que o investimento é realizado.\"}}, \"required\": [\"principal\", \"interest_rate\", \"years\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda com meu investimento. Eu tenho $5000 que quero investir a uma taxa de juros anual de 5%. Eu pretendo manter esse investimento por 10 anos. Você pode me dizer qual será o valor futuro do meu investimento?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_future_value\", \"arguments\": {\"principal\": 5000, \"interest_rate\": 5, \"years\": 10}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_future_value"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipe\", \"description\": \"Procure uma receita por ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"Os ingredientes para procurar.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu tenho frango, brócolis e queijo. O que posso fazer com isso?",
+      "completion": "<tool_call>\n{\"name\": \"search_recipe\", \"arguments\": {\"ingredients\": [\"chicken\", \"broccoli\", \"cheese\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_recipe"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_area\", \"description\": \"Calcule a área de uma forma.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"shape\": {\"type\": \"string\", \"description\": \"A forma para calcular a área\"}, \"dimensions\": {\"type\": \"array\", \"description\": \"As dimensões da forma\"}}, \"required\": [\"shape\", \"dimensions\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular a área de um retângulo. O comprimento é 10 e a largura é 5.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_area\", \"arguments\": {\"shape\": \"rectangle\", \"dimensions\": [10, 5]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_area"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"A localização da origem.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_qr_code\", \"description\": \"Gerar um código QR para os dados fornecidos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"data\": {\"type\": \"string\", \"description\": \"Os dados a serem codificados no código QR.\"}}, \"required\": [\"data\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova Iorque e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance",
+        "generate_qr_code"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"O idioma do texto de origem.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma para se traduzir.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"O local inicial.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso traduzir uma frase do inglês para o francês. A frase é \"Olá, como você está?\"",
+      "completion": "<tool_call>\n{\"name\": \"translate_text\", \"arguments\": {\"text\": \"Hello, how are you?\", \"source_language\": \"English\", \"target_language\": \"French\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "translate_text",
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birth_date\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birth_date\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"A quantidade para converter\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter para\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 15-05-1990. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birth_date\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age",
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news\", \"description\": \"Obtenha as últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"Categoria de notícias preferidas (por exemplo, esportes, tecnologia, política).\"}, \"country\": {\"type\": \"string\", \"description\": \"País de notícias preferidas (por exemplo, EUA, Reino Unido, Índia).\"}}, \"required\": [\"category\", \"country\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me trazer as últimas notícias esportivas dos EUA?",
+      "completion": "<tool_call>\n{\"name\": \"get_news\", \"arguments\": {\"category\": \"sports\", \"country\": \"US\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_news"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes sobre um filme específico.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_loan_payment\", \"description\": \"Calcule o pagamento mensal por um empréstimo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"loan_amount\": {\"type\": \"number\", \"description\": \"O valor total do empréstimo.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual para o empréstimo.\"}, \"loan_term\": {\"type\": \"integer\", \"description\": \"A duração do empréstimo em meses.\"}}, \"required\": [\"loan_amount\", \"interest_rate\", \"loan_term\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me contar sobre o filme \"A Origem\"?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"title\": \"Inception\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details",
+        "calculate_loan_payment"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birthdate\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule a quantidade da ponta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor total da fatura\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de gorjeta\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age",
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_car_emissions\", \"description\": \"Calcule as emissões de carbono de um carro com base no consumo de combustível e na distância percorrida.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"fuel_consumption\": {\"type\": \"number\", \"description\": \"O consumo de combustível do carro em litros por 100 quilômetros.\"}, \"distance\": {\"type\": \"number\", \"description\": \"A distância percorrida pelo carro em quilômetros.\"}}, \"required\": [\"fuel_consumption\", \"distance\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu quero calcular as emissões de carbono do meu carro. Eu viajei 500 quilômetros e o consumo de combustível do meu carro é de 7 litros a cada 100 quilômetros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_car_emissions\", \"arguments\": {\"fuel_consumption\": 7, \"distance\": 500}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_car_emissions"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de um tipo para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso converter 500 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_email_availability\", \"description\": \"Verifique a disponibilidade de um endereço de e -mail.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"email\": {\"type\": \"string\", \"description\": \"O endereço de e -mail para verificar.\"}}, \"required\": [\"email\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu quero criar uma nova conta de email. Você pode verificar se o endereço de email \"john.doe@gmail.com\" está disponível?",
+      "completion": "<tool_call>\n{\"name\": \"check_email_availability\", \"arguments\": {\"email\": \"john.doe@gmail.com\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "check_email_availability"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base no total da fatura e na porcentagem de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_total\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta a ser dada.\"}}, \"required\": [\"bill_total\", \"tip_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_jobs\", \"description\": \"Pesquise listagens de empregos com base em palavras -chave e localização.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"As palavras -chave a serem pesquisadas nas listagens de empregos.\"}, \"location\": {\"type\": \"string\", \"description\": \"O local para procurar listagens de empregos.\"}}, \"required\": [\"keywords\", \"location\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. O valor total da conta é de $50 e eu quero dar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_total\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip",
+        "search_jobs"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birth_date\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birth_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birth_date\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"integer\", \"description\": \"O valor mínimo do intervalo.\"}, \"max\": {\"type\": \"integer\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min\", \"max\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato yyyy-mm-dd.\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min\": 1, \"max\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number",
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_profit_margin\", \"description\": \"Calcule a margem de lucro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"revenue\": {\"type\": \"number\", \"description\": \"A receita total.\"}, \"cost\": {\"type\": \"number\", \"description\": \"O custo total.\"}}, \"required\": [\"revenue\", \"cost\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular minha margem de lucro. Minha receita total foi de $5000 e meu custo total foi de $3000.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_profit_margin\", \"arguments\": {\"revenue\": 5000, \"cost\": 3000}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_profit_margin"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"category\": {\"type\": \"string\", \"description\": \"A categoria de livros para pesquisar.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros para procurar.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou procurando um livro sobre o tema da inteligência artificial. Você pode me ajudar a encontrar um?",
+      "completion": "<tool_call>\n{\"name\": \"search_books\", \"arguments\": {\"keywords\": [\"artificial intelligence\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou autor do livro.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou procurando um livro, mas não consigo lembrar o título completo. É algo como \"Para matar um\".",
+      "completion": "<tool_call>\n{\"name\": \"search_book\", \"arguments\": {\"query\": \"To Kill a\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_average\", \"description\": \"Calcule a média de uma lista de números.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"numbers\": {\"type\": \"array\", \"items\": {\"type\": \"number\"}, \"description\": \"A lista de números.\"}}, \"required\": [\"numbers\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu tenho uma lista de números e preciso encontrar a média. Os números são 5, 10, 15, 20, 25.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_average\", \"arguments\": {\"numbers\": [5, 10, 15, 20, 25]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_average"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu IMC. Eu peso 70 quilos e minha altura é 1,75 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem procuradas nos livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou procurando livros sobre o tema da inteligência artificial. Você pode me ajudar a encontrar alguns?",
+      "completion": "<tool_call>\n{\"name\": \"search_books\", \"arguments\": {\"keywords\": [\"artificial intelligence\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"track_package\", \"description\": \"Acompanhe o status de um pacote.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"tracking_number\": {\"type\": \"string\", \"description\": \"O número de rastreamento do pacote.\"}}, \"required\": [\"tracking_number\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme baseado em título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso rastrear meu pacote. O número de rastreamento é 123456789.",
+      "completion": "<tool_call>\n{\"name\": \"track_package\", \"arguments\": {\"tracking_number\": \"123456789\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "track_package",
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"number\", \"description\": \"O valor mínimo do intervalo.\"}, \"max\": {\"type\": \"number\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min\", \"max\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min\": 1, \"max\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"Os ingredientes disponíveis.\"}, \"cuisine\": {\"type\": \"string\", \"description\": \"A cozinha preferida.\"}, \"dietary_restrictions\": {\"type\": \"array\", \"description\": \"As restrições alimentares.\"}}, \"required\": [\"ingredients\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"source\": {\"type\": \"string\", \"description\": \"O local da fonte.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"source\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu tenho um pouco de frango, tomates e alho. Você pode me encontrar uma receita?",
+      "completion": "<tool_call>\n{\"name\": \"search_recipes\", \"arguments\": {\"ingredients\": [\"chicken\", \"tomatoes\", \"garlic\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_recipes",
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_palindrome\", \"description\": \"Verifique se uma determinada palavra ou frase é um palíndromo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser verificado.\"}}, \"required\": [\"text\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_mortgage_payment\", \"description\": \"Calcule o pagamento mensal da hipoteca.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"loan_amount\": {\"type\": \"number\", \"description\": \"O valor do empréstimo.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual.\"}, \"loan_term\": {\"type\": \"integer\", \"description\": \"O prazo do empréstimo em anos.\"}}, \"required\": [\"loan_amount\", \"interest_rate\", \"loan_term\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode verificar se \"racecar\" é um palíndromo?",
+      "completion": "<tool_call>\n{\"name\": \"check_palindrome\", \"arguments\": {\"text\": \"racecar\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "check_palindrome",
+        "calculate_mortgage_payment"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base na porcentagem total da fatura e da gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"total_bill\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta.\"}}, \"required\": [\"total_bill\", \"tip_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um determinado intervalo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"integer\", \"description\": \"O valor mínimo do intervalo.\"}, \"max\": {\"type\": \"integer\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min\", \"max\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. A conta total é de $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"total_bill\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip",
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_spelling\", \"description\": \"Verifique a ortografia de uma determinada palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para verificar a ortografia de.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode verificar a grafia da palavra 'accomodate' para mim?",
+      "completion": "<tool_call>\n{\"name\": \"check_spelling\", \"arguments\": {\"word\": \"accomodate\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "check_spelling"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o IMC (índice de massa corporal).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"Peso do usuário em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"Altura do usuário em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu quero calcular meu IMC. Eu peso 70 quilogramas e minha altura é 1,75 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC) com base na altura e peso.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"height\": {\"type\": \"number\", \"description\": \"A altura em metros\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas\"}}, \"required\": [\"height\", \"weight\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Minha altura é 1,75 metros e meu peso é 68 quilos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"height\": 1.75, \"weight\": 68}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi",
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações para uma determinada empresa.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"company\": {\"type\": \"string\", \"description\": \"O nome da empresa.\"}}, \"required\": [\"company\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_restaurants\", \"description\": \"Procure restaurantes baseados na localização e cozinha.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"O local para procurar restaurantes.\"}, \"cuisine\": {\"type\": \"string\", \"description\": \"O tipo de cozinha a procurar.\"}}, \"required\": [\"location\", \"cuisine\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"company\": \"Apple\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price",
+        "search_restaurants"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"get_random_fact\", \"description\": \"Obtenha um fato aleatório de uma categoria específica.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria do fato.\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu IMC. Eu peso 75 kg e minha altura é de 1,8 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 75, \"height\": 1.8}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi",
+        "get_random_fact"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto para um determinado item.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto a ser aplicada.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi um vestido que gostei. O preço original era de $100, mas está com um desconto de 20%. Você pode me dizer quanto vai custar após o desconto?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 100, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location1\": {\"type\": \"string\", \"description\": \"O primeiro local.\"}, \"location2\": {\"type\": \"string\", \"description\": \"O segundo local.\"}}, \"required\": [\"location1\", \"location2\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_interest\", \"description\": \"Calcule o valor dos juros para um determinado valor, taxa e tempo principal.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"principal_amount\": {\"type\": \"number\", \"description\": \"O valor principal.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros.\"}, \"time\": {\"type\": \"integer\", \"description\": \"A duração do tempo em anos.\"}}, \"required\": [\"principal_amount\", \"interest_rate\", \"time\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"location1\": \"New York\", \"location2\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance",
+        "calculate_interest"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age_difference\", \"description\": \"Calcule a diferença de idade entre duas pessoas.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"person1_age\": {\"type\": \"integer\", \"description\": \"A idade da primeira pessoa.\"}, \"person2_age\": {\"type\": \"integer\", \"description\": \"A idade da segunda pessoa.\"}}, \"required\": [\"person1_age\", \"person2_age\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular a diferença de idade entre meu irmão e eu. Eu tenho 28 anos e meu irmão tem 34 anos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age_difference\", \"arguments\": {\"person1_age\": 28, \"person2_age\": 34}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age_difference"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"O local inicial.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location1\": {\"type\": \"string\", \"description\": \"O primeiro local.\"}, \"location2\": {\"type\": \"string\", \"description\": \"O segundo local.\"}}, \"required\": [\"location1\", \"location2\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova Iorque e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance",
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"analyze_sentiment\", \"description\": \"Analisar o sentimento de um texto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para analisar.\"}}, \"required\": [\"text\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode analisar o sentimento deste texto para mim? \"Estou me sentindo realmente feliz hoje porque eu recebi uma promoção no trabalho.\"",
+      "completion": "<tool_call>\n{\"name\": \"analyze_sentiment\", \"arguments\": {\"text\": \"I am feeling really happy today because I got a promotion at work.\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "analyze_sentiment"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"O local inicial.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"stock_symbol\": {\"type\": \"string\", \"description\": \"O símbolo do estoque.\"}}, \"required\": [\"stock_symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber o preço atual das ações da Apple.",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"stock_symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base no total da conta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_total\": {\"type\": \"number\", \"description\": \"O valor total da conta.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta a ser dada.\"}}, \"required\": [\"bill_total\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O total da minha conta é $85 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_total\": 85, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de um tipo para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"A quantidade de moeda para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"A lista de ingredientes.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu tenho frango, brócolis e queijo. O que posso fazer com isso?",
+      "completion": "<tool_call>\n{\"name\": \"search_recipes\", \"arguments\": {\"ingredients\": [\"chicken\", \"broccoli\", \"cheese\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_recipes"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"O local inicial.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra específica.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter a definição.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nO que significa a palavra 'serendipidade'?",
+      "completion": "<tool_call>\n{\"name\": \"get_definition\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_definition"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento no formato aaaaa-mm-dd\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me ajudar a calcular a minha idade? Eu nasci em 15-05-1990.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso converter 1000 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de uma unidade para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"create_todo\", \"description\": \"Crie um novo item de TODO.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"task\": {\"type\": \"string\", \"description\": \"A descrição da tarefa.\"}, \"due_date\": {\"type\": \"string\", \"description\": \"A data de vencimento da tarefa.\"}}, \"required\": [\"task\", \"due_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 USD para EUR. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency",
+        "create_todo"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o valor do desconto por um determinado preço.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"price\": {\"type\": \"number\", \"description\": \"O preço original.\"}, \"discount_percentage\": {\"type\": \"integer\", \"description\": \"A porcentagem do desconto.\"}}, \"required\": [\"price\", \"discount_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"O conteúdo da mensagem de email.\"}}, \"required\": [\"recipient\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu comprei um vestido por $200 e recebi um desconto de 20%. Quanto eu economizei?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount",
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_mortgage\", \"description\": \"Calcule o pagamento mensal da hipoteca.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"loan_amount\": {\"type\": \"number\", \"description\": \"O valor do empréstimo.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual.\"}, \"loan_term\": {\"type\": \"integer\", \"description\": \"O prazo do empréstimo em anos.\"}}, \"required\": [\"loan_amount\", \"interest_rate\", \"loan_term\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso de ajuda para calcular meu pagamento da hipoteca. Eu tenho um valor de empréstimo de $200.000, uma taxa de juros anual de 3,5% e um prazo de empréstimo de 30 anos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_mortgage\", \"arguments\": {\"loan_amount\": 200000, \"interest_rate\": 3.5, \"loan_term\": 30}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_mortgage"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Eu peso 75 quilos e minha altura é 1,8 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 75, \"height\": 1.8}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"origin\": {\"type\": \"string\", \"description\": \"A localização da origem.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"origin\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"origin\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"date_of_birth\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"date_of_birth\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 15 de maio de 1990. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"date_of_birth\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me ajudar a calcular minha idade? Eu nasci em 15-05-1990.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o IMC (índice de massa corporal).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}}, \"required\": [\"height\", \"weight\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Minha altura é 1,75 metros e meu peso é 68 quilos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"height\": 1.75, \"weight\": 68}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o IMC (índice de massa corporal).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso da pessoa em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura da pessoa em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Eu peso 70 quilos e minha altura é 1,75 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou gênero a procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou com vontade de assistir a um filme de comédia. Você pode sugerir alguns?",
+      "completion": "<tool_call>\n{\"name\": \"search_movies\", \"arguments\": {\"query\": \"comedy\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}}, \"required\": [\"height\", \"weight\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_password\", \"description\": \"Gerar uma senha aleatória.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu IMC. Minha altura é 1,75 metros e meu peso é 68 quilogramas.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"height\": 1.75, \"weight\": 68}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi",
+        "generate_password"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um determinado intervalo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min_value\": {\"type\": \"integer\", \"description\": \"O valor mínimo do intervalo.\"}, \"max_value\": {\"type\": \"integer\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min_value\", \"max_value\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from\", \"to\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min_value\": 1, \"max_value\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number",
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule a quantidade da ponta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_password\", \"description\": \"Gerar uma senha aleatória.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O valor da minha conta é $50 e eu quero deixar uma gorjeta de 20%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 50, \"tip_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip",
+        "generate_password"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"play_music\", \"description\": \"Toque música com base nas preferências do usuário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero musical.\"}, \"mood\": {\"type\": \"string\", \"description\": \"O humor do usuário.\"}}, \"required\": [\"genre\", \"mood\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou me sentindo um pouco pra baixo hoje. Você pode tocar um pouco de blues para mim?",
+      "completion": "<tool_call>\n{\"name\": \"play_music\", \"arguments\": {\"genre\": \"blues\", \"mood\": \"down\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "play_music"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"analyze_sentiment\", \"description\": \"Analisar o sentimento de um texto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para analisar.\"}}, \"required\": [\"text\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode analisar o sentimento deste texto para mim? \"Estou me sentindo tão feliz hoje porque recebi uma promoção no trabalho.\"",
+      "completion": "<tool_call>\n{\"name\": \"analyze_sentiment\", \"arguments\": {\"text\": \"I am feeling so happy today because I got a promotion at work.\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "analyze_sentiment"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Eu peso 70 quilos e minha altura é 1,75 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"integer\", \"description\": \"O valor mínimo do intervalo.\"}, \"max\": {\"type\": \"integer\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min\", \"max\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto com base na porcentagem de preços e desconto originais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min\": 1, \"max\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number",
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"analyze_sentiment\", \"description\": \"Analisar o sentimento de um texto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para analisar.\"}}, \"required\": [\"text\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode analisar o sentimento deste texto para mim? \"Estou me sentindo realmente feliz hoje porque recebi uma promoção no trabalho.\"",
+      "completion": "<tool_call>\n{\"name\": \"analyze_sentiment\", \"arguments\": {\"text\": \"I am feeling really happy today because I got a promotion at work.\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "analyze_sentiment"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tax\", \"description\": \"Calcule o valor do imposto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"income\": {\"type\": \"number\", \"description\": \"A renda anual.\"}, \"deductions\": {\"type\": \"number\", \"description\": \"As deduções totais.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto em porcentagem.\"}}, \"required\": [\"income\", \"tax_rate\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"search_product\", \"description\": \"Procure um produto em uma loja online.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"product_name\": {\"type\": \"string\", \"description\": \"O nome do produto.\"}, \"category\": {\"type\": \"string\", \"description\": \"A categoria do produto.\"}}, \"required\": [\"product_name\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular meu imposto. Minha renda anual é de $100.000 e minhas deduções totais são de $20.000. A alíquota de imposto é de 30%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tax\", \"arguments\": {\"income\": 100000, \"deductions\": 20000, \"tax_rate\": 30}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tax",
+        "search_product"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tax\", \"description\": \"Calcule o valor do imposto com base na renda e taxa de imposto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"income\": {\"type\": \"number\", \"description\": \"O valor da renda.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto em porcentagem.\"}}, \"required\": [\"income\", \"tax_rate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu imposto. Minha renda é de $50000 e a alíquota do imposto é de 20%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tax\", \"arguments\": {\"income\": 50000, \"tax_rate\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tax"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"O desconto percentual.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency",
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base na porcentagem total da fatura e da gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"total_bill\": {\"type\": \"number\", \"description\": \"O valor total da fatura\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta\"}}, \"required\": [\"total_bill\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso de ajuda para calcular a gorjeta da minha conta. A conta total é de $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"total_bill\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter a definição de.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nQual é a definição da palavra 'serendipidade'?",
+      "completion": "<tool_call>\n{\"name\": \"get_definition\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_definition"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_weight\", \"description\": \"Converter peso de uma unidade para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"from_unit\": {\"type\": \"string\", \"description\": \"A unidade para converter de.\"}, \"to_unit\": {\"type\": \"string\", \"description\": \"A unidade para se converter.\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso a ser convertido.\"}}, \"required\": [\"from_unit\", \"to_unit\", \"weight\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 10 quilogramas para libras. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_weight\", \"arguments\": {\"from_unit\": \"kilograms\", \"to_unit\": \"pounds\", \"weight\": 10}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_weight",
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"date_of_birth\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"date_of_birth\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"date_of_birth\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tax\", \"description\": \"Calcule o valor do imposto para uma determinada renda.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"income\": {\"type\": \"number\", \"description\": \"O valor da renda.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto como uma porcentagem.\"}}, \"required\": [\"income\", \"tax_rate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu imposto para este ano. Minha renda é $50000 e a taxa de imposto é 20%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tax\", \"arguments\": {\"income\": 50000, \"tax_rate\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tax"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter a definição.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nO que significa a palavra 'serendipidade'?",
+      "completion": "<tool_call>\n{\"name\": \"get_definition\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_definition"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O destinatário do email.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"A mensagem de email.\"}}, \"required\": [\"recipient\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nPreciso enviar um e-mail para meu chefe. O destinatário é boss@company.com. O assunto é \"Relatório Mensal\" e a mensagem é \"Por favor, encontre em anexo o relatório mensal para sua análise.\"",
+      "completion": "<tool_call>\n{\"name\": \"send_email\", \"arguments\": {\"recipient\": \"boss@company.com\", \"subject\": \"Monthly Report\", \"message\": \"Please find attached the monthly report for your review.\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birth_date\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato aaaaa-dd\"}}, \"required\": [\"birth_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 15 de maio de 1990. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birth_date\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC) com base na altura e peso.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}}, \"required\": [\"height\", \"weight\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Minha altura é 1,75 metros e meu peso é 68 quilos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"height\": 1.75, \"weight\": 68}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações de uma empresa.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"company\": {\"type\": \"string\", \"description\": \"O nome da empresa.\"}}, \"required\": [\"company\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"company\": \"Apple\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC), dado o peso e a altura.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu IMC. Eu peso 70 kg e minha altura é 1,75 m.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações de uma empresa.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"company\": {\"type\": \"string\", \"description\": \"O nome da empresa.\"}}, \"required\": [\"company\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nQual é o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"company\": \"Apple\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"date_of_birth\": {\"type\": \"string\", \"description\": \"A data de nascimento no formato: AAAA-MM-DD\"}}, \"required\": [\"date_of_birth\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"date_of_birth\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discounted_price\", \"description\": \"Calcule o preço com desconto de um produto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do produto.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto aplicada ao produto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu vi um vestido que gostei em uma loja. O preço original era de $100, mas está com um desconto de 20%. Você pode me ajudar a calcular quanto eu terei que pagar se a taxa de imposto for de 5%?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discounted_price\", \"arguments\": {\"original_price\": 100, \"discount_percentage\": 20, \"tax_rate\": 5}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discounted_price"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter a definição.\"}}, \"required\": [\"word\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discounted_price\", \"description\": \"Calcule o preço com desconto de um produto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do produto.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nQual é o significado da palavra \"serendipidade\"?",
+      "completion": "<tool_call>\n{\"name\": \"get_definition\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_definition",
+        "calculate_discounted_price"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"analyze_sentiment\", \"description\": \"Analise o sentimento de um texto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para analisar.\"}}, \"required\": [\"text\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode analisar o sentimento deste texto para mim? \"Estou me sentindo realmente feliz hoje porque recebi uma promoção no trabalho.\"",
+      "completion": "<tool_call>\n{\"name\": \"analyze_sentiment\", \"arguments\": {\"text\": \"I am feeling really happy today because I got a promotion at work.\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "analyze_sentiment"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}, \"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}}, \"required\": [\"from_currency\", \"to_currency\", \"amount\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"play_music\", \"description\": \"Toque música baseada no gênero ou artista dado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero da música para tocar.\"}, \"artist\": {\"type\": \"string\", \"description\": \"O artista para tocar música.\"}}, \"required\": [\"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"from_currency\": \"USD\", \"to_currency\": \"EUR\", \"amount\": 500}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency",
+        "play_music"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_website_availability\", \"description\": \"Verifique a disponibilidade de um site.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"website\": {\"type\": \"string\", \"description\": \"O URL do site para verificar.\"}}, \"required\": [\"website\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode verificar se www.google.com está disponível?",
+      "completion": "<tool_call>\n{\"name\": \"check_website_availability\", \"arguments\": {\"website\": \"www.google.com\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "check_website_availability"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"number\", \"description\": \"O valor mínimo do intervalo.\"}, \"max\": {\"type\": \"number\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min\", \"max\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min\": 1, \"max\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_temperature\", \"description\": \"Converter a temperatura de uma unidade para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"temperature\": {\"type\": \"number\", \"description\": \"O valor da temperatura.\"}, \"from_unit\": {\"type\": \"string\", \"description\": \"A unidade de temperatura para converter de.\"}, \"to_unit\": {\"type\": \"string\", \"description\": \"A unidade de temperatura para se converter.\"}}, \"required\": [\"temperature\", \"from_unit\", \"to_unit\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu tenho uma temperatura em Fahrenheit e quero converter para Celsius. A temperatura é 98,6 graus.",
+      "completion": "<tool_call>\n{\"name\": \"convert_temperature\", \"arguments\": {\"temperature\": 98.6, \"from_unit\": \"Fahrenheit\", \"to_unit\": \"Celsius\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_temperature"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"play_music\", \"description\": \"Tocar música.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"song\": {\"type\": \"string\", \"description\": \"O nome da música a ser tocado.\"}}, \"required\": [\"song\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu quero ouvir um pouco de música. Você pode tocar 'Bohemian Rhapsody' do Queen?",
+      "completion": "<tool_call>\n{\"name\": \"play_music\", \"arguments\": {\"song\": \"Bohemian Rhapsody\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "play_music"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de um tipo para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato yyyy-mm-dd\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo do ticker do estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, você pode me dizer o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discounted_price\", \"description\": \"Calcule o preço com desconto com base no preço original e no valor do desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_amount\": {\"type\": \"number\", \"description\": \"O valor do desconto.\"}}, \"required\": [\"original_price\", \"discount_amount\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu vi um vestido que gostei em uma loja. O preço original era de $100, mas está com um desconto de 20%. Você pode me dizer quanto custará depois do desconto?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discounted_price\", \"arguments\": {\"original_price\": 100, \"discount_amount\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discounted_price"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para a qual a definição é necessária.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem da definição.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nQual é a definição da palavra 'serendipidade'?",
+      "completion": "<tool_call>\n{\"name\": \"get_definition\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_definition"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi uma jaqueta que gostei em uma loja. O preço original era de $200, mas há um desconto de 20%. Você pode me dizer quanto custará após o desconto?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"integer\", \"description\": \"O valor mínimo do intervalo.\"}, \"max\": {\"type\": \"integer\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min\", \"max\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min\": 1, \"max\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_translation\", \"description\": \"Obtenha a tradução de um determinado texto em um idioma especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso traduzir uma frase para o francês. A frase é \"Olá, como você está?\"",
+      "completion": "<tool_call>\n{\"name\": \"get_translation\", \"arguments\": {\"text\": \"Hello, how are you?\", \"target_language\": \"French\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_translation"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"title\", \"genre\", \"year\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"validate_email\", \"description\": \"Validar se um endereço de email for válido.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"email\": {\"type\": \"string\", \"description\": \"O endereço de e -mail.\"}}, \"required\": [\"email\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou procurando um filme de comédia lançado em 2015. Você pode me ajudar a encontrar um?",
+      "completion": "<tool_call>\n{\"name\": \"search_movies\", \"arguments\": {\"title\": \"\", \"genre\": \"comedy\", \"year\": 2015}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_movies",
+        "validate_email"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"date_of_birth\": {\"type\": \"string\", \"description\": \"A data de nascimento.\"}}, \"required\": [\"date_of_birth\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"check_stock_price\", \"description\": \"Verifique o preço atual das ações de uma determinada empresa.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"company\": {\"type\": \"string\", \"description\": \"O nome da empresa.\"}}, \"required\": [\"company\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 15 de maio de 1990. Você pode me dizer quantos anos eu tenho?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"date_of_birth\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age",
+        "check_stock_price"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age_in_seconds\", \"description\": \"Calcule a idade em segundos com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"date_of_birth\": {\"type\": \"string\", \"description\": \"A data de nascimento.\"}, \"current_date\": {\"type\": \"string\", \"description\": \"A data atual.\"}}, \"required\": [\"date_of_birth\", \"current_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho em segundos?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age_in_seconds\", \"arguments\": {\"date_of_birth\": \"1990-05-15\", \"current_date\": \"2022-03-01\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age_in_seconds"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um determinado intervalo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min_value\": {\"type\": \"number\", \"description\": \"O valor mínimo do intervalo.\"}, \"max_value\": {\"type\": \"number\", \"description\": \"O valor máximo do intervalo.\"}}, \"required\": [\"min_value\", \"max_value\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min_value\": 1, \"max_value\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_average\", \"description\": \"Calcule a média de um determinado conjunto de números.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"numbers\": {\"type\": \"array\", \"items\": {\"type\": \"number\"}, \"description\": \"O conjunto de números.\"}}, \"required\": [\"numbers\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_square_root\", \"description\": \"Calcule a raiz quadrada de um número.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"number\": {\"type\": \"number\", \"description\": \"O número para calcular a raiz quadrada.\"}}, \"required\": [\"number\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu tenho um conjunto de números e preciso encontrar a média. Os números são 5, 10, 15, 20, 25.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_average\", \"arguments\": {\"numbers\": [5, 10, 15, 20, 25]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_average",
+        "calculate_square_root"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_fuel_consumption\", \"description\": \"Calcule o consumo de combustível com base na eficiência de distância e combustível.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"distance\": {\"type\": \"number\", \"description\": \"A distância percorrida.\"}, \"fuel_efficiency\": {\"type\": \"number\", \"description\": \"A eficiência de combustível em quilômetros por litro.\"}}, \"required\": [\"distance\", \"fuel_efficiency\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_profit_margin\", \"description\": \"Calcule a porcentagem de margem de lucro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"revenue\": {\"type\": \"number\", \"description\": \"A receita total.\"}, \"cost\": {\"type\": \"number\", \"description\": \"O custo total.\"}}, \"required\": [\"revenue\", \"cost\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso calcular quanto combustível consumirei durante minha viagem. Eu vou viajar 500 quilômetros e meu carro tem uma eficiência de combustível de 15 quilômetros por litro. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_fuel_consumption\", \"arguments\": {\"distance\": 500, \"fuel_efficiency\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_fuel_consumption",
+        "calculate_profit_margin"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato yyyy-mm-dd\"}}, \"required\": [\"birthdate\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta com base na fatura total e percentual de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"total_bill\": {\"type\": \"number\", \"description\": \"O valor total da fatura\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta\"}}, \"required\": [\"total_bill\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age",
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato yyyy-mm-dd\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode me dizer quantos anos eu tenho? Minha data de nascimento é 1990-05-15.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto com base na porcentagem de preços e desconto originais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi uma jaqueta que gostei em uma loja. O preço original era de $200, mas há um desconto de 20%. Você pode me dizer quanto custará após o desconto?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount",
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da dica para uma fatura.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor da conta.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem da ponta.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois pontos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"latitude1\": {\"type\": \"number\", \"description\": \"A latitude do primeiro ponto.\"}, \"longitude1\": {\"type\": \"number\", \"description\": \"A longitude do primeiro ponto.\"}, \"latitude2\": {\"type\": \"number\", \"description\": \"A latitude do segundo ponto.\"}, \"longitude2\": {\"type\": \"number\", \"description\": \"A longitude do segundo ponto.\"}}, \"required\": [\"latitude1\", \"longitude1\", \"latitude2\", \"longitude2\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta da minha conta. A conta total é de $100 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 100, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip",
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location1\": {\"type\": \"string\", \"description\": \"O primeiro local.\"}, \"location2\": {\"type\": \"string\", \"description\": \"O segundo local.\"}}, \"required\": [\"location1\", \"location2\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova Iorque e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"location1\": \"New York\", \"location2\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter a definição de.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem da palavra.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nO que significa a palavra 'serendipidade'?",
+      "completion": "<tool_call>\n{\"name\": \"get_definition\", \"arguments\": {\"word\": \"serendipity\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_definition"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu preciso converter 1000 USD para Euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes de um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"title\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_password\", \"description\": \"Gere uma senha aleatória com comprimento e critérios específicos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}, \"include_uppercase\": {\"type\": \"boolean\", \"description\": \"Inclua letras maiúsculas na senha.\"}, \"include_lowercase\": {\"type\": \"boolean\", \"description\": \"Inclua letras minúsculas na senha.\"}, \"include_numbers\": {\"type\": \"boolean\", \"description\": \"Inclua números na senha.\"}, \"include_symbols\": {\"type\": \"boolean\", \"description\": \"Inclua símbolos na senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode me contar sobre o filme \"A Origem\"?",
+      "completion": "<tool_call>\n{\"name\": \"get_movie_details\", \"arguments\": {\"title\": \"Inception\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_movie_details",
+        "generate_random_password"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"analyze_sentiment\", \"description\": \"Analisar o sentimento de um texto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser analisado.\"}}, \"required\": [\"text\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discounted_price\", \"description\": \"Calcule o preço com desconto de um produto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"product_price\": {\"type\": \"number\", \"description\": \"O preço original do produto.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"O desconto percentual.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto aplicada.\"}}, \"required\": [\"product_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode analisar o sentimento deste texto para mim? \"Estou me sentindo muito feliz hoje porque recebi uma promoção no trabalho.\"",
+      "completion": "<tool_call>\n{\"name\": \"analyze_sentiment\", \"arguments\": {\"text\": \"I am feeling very happy today because I got a promotion at work.\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "analyze_sentiment",
+        "calculate_discounted_price"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Eu peso 70 kg e minha altura é 1,75 m.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento.\"}}, \"required\": [\"birthdate\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"get_definition\", \"description\": \"Obtenha a definição de uma palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para obter a definição.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age",
+        "get_definition"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Eu peso 70 quilos e minha altura é 1,75 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 70, \"height\": 1.75}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"get_news_headlines\", \"description\": \"Obtenha as manchetes das últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias.\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 500 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 500, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency",
+        "get_news_headlines"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_carbon_footprint\", \"description\": \"Calcule a pegada de carbono com base em vários fatores.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"mileage\": {\"type\": \"number\", \"description\": \"A milhagem de um veículo.\"}, \"fuel_type\": {\"type\": \"string\", \"description\": \"O tipo de combustível usado.\"}, \"electricity_usage\": {\"type\": \"number\", \"description\": \"O uso de eletricidade em quilowatt-hora.\"}}, \"required\": [\"mileage\", \"fuel_type\", \"electricity_usage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu quero calcular minha pegada de carbono. Eu dirijo um carro a diesel que faz 15 milhas por galão. Eu também consumo cerca de 500 quilowatt-horas de eletricidade por mês.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_carbon_footprint\", \"arguments\": {\"mileage\": 15, \"fuel_type\": \"diesel\", \"electricity_usage\": 500}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_carbon_footprint"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter moeda de um tipo para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor a ser convertido.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_loan_payment\", \"description\": \"Calcule o pagamento mensal do empréstimo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"loan_amount\": {\"type\": \"number\", \"description\": \"O valor do empréstimo.\"}, \"interest_rate\": {\"type\": \"number\", \"description\": \"A taxa de juros anual.\"}, \"loan_term\": {\"type\": \"integer\", \"description\": \"O prazo do empréstimo em anos.\"}}, \"required\": [\"loan_amount\", \"interest_rate\", \"loan_term\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso converter 1000 dólares americanos para euros. Você pode me ajudar com isso?",
+      "completion": "<tool_call>\n{\"name\": \"convert_currency\", \"arguments\": {\"amount\": 1000, \"from_currency\": \"USD\", \"to_currency\": \"EUR\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "convert_currency",
+        "calculate_loan_payment"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"schedule_meeting\", \"description\": \"Programe uma reunião com participantes e tempo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"participants\": {\"type\": \"array\", \"description\": \"Os participantes da reunião.\"}, \"time\": {\"type\": \"string\", \"description\": \"A hora da reunião.\"}}, \"required\": [\"participants\", \"time\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso agendar uma reunião com John, Sarah e Mike às 15h de amanhã.",
+      "completion": "<tool_call>\n{\"name\": \"schedule_meeting\", \"arguments\": {\"participants\": [\"John\", \"Sarah\", \"Mike\"], \"time\": \"3pm tomorrow\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "schedule_meeting"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_age\", \"description\": \"Calcule a idade com base na data de nascimento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"birthdate\": {\"type\": \"string\", \"description\": \"A data de nascimento em formato AAAA-MM-DD\"}}, \"required\": [\"birthdate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu nasci em 1990-05-15. Você pode me dizer quantos anos eu tenho hoje?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_age\", \"arguments\": {\"birthdate\": \"1990-05-15\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_age"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location1\": {\"type\": \"string\", \"description\": \"O primeiro local.\"}, \"location2\": {\"type\": \"string\", \"description\": \"O segundo local.\"}}, \"required\": [\"location1\", \"location2\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso saber a distância entre Nova York e Los Angeles.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"location1\": \"New York\", \"location2\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tax\", \"description\": \"Calcule o valor do imposto por um determinado preço.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"price\": {\"type\": \"number\", \"description\": \"O preço.\"}, \"tax_rate\": {\"type\": \"number\", \"description\": \"A taxa de imposto.\"}}, \"required\": [\"price\", \"tax_rate\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular o imposto para um produto que estou vendendo. O preço é $200 e a taxa de imposto é de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tax\", \"arguments\": {\"price\": 200, \"tax_rate\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tax"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}, \"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}}, \"required\": [\"height\", \"weight\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu gostaria de calcular meu IMC. Minha altura é 1,75 metros e eu peso 70 quilos.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"height\": 1.75, \"weight\": 70}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_website_availability\", \"description\": \"Verifique se um site está disponível no momento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"website_url\": {\"type\": \"string\", \"description\": \"O URL do site para verificar.\"}}, \"required\": [\"website_url\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, você pode verificar se www.google.com está disponível?",
+      "completion": "<tool_call>\n{\"name\": \"check_website_availability\", \"arguments\": {\"website_url\": \"www.google.com\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "check_website_availability"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto de um produto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do produto.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto a ser aplicada.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi um vestido que eu gostei. O preço original era de $100, mas está com um desconto de 20%. Quanto custará agora?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 100, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da dica para uma fatura.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor total da fatura.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de ponta a ser aplicada.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular uma gorjeta. O valor da minha conta é $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 50, \"tip_percentage\": 15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o valor do desconto com base na porcentagem de preço e desconto original.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu vi uma jaqueta que gostei em uma loja. O preço original era de $200, mas está em promoção com 20% de desconto. Qual é o valor do desconto que estou recebendo?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero dos livros.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou procurando um livro de mistério de Agatha Christie.",
+      "completion": "<tool_call>\n{\"name\": \"search_books\", \"arguments\": {\"keywords\": \"mystery\", \"author\": \"Agatha Christie\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nQual é o preço atual das ações da Apple?",
+      "completion": "<tool_call>\n{\"name\": \"get_stock_price\", \"arguments\": {\"symbol\": \"AAPL\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_tip\", \"description\": \"Calcule o valor da ponta para um determinado valor da fatura e porcentagem de gorjeta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"bill_amount\": {\"type\": \"number\", \"description\": \"O valor da fatura em dólares.\"}, \"tip_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem da ponta como decimal.\"}}, \"required\": [\"bill_amount\", \"tip_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular a gorjeta para a minha conta. O valor total é $50 e eu quero deixar uma gorjeta de 15%.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_tip\", \"arguments\": {\"bill_amount\": 50, \"tip_percentage\": 0.15}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_tip"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"find_nearby_restaurants\", \"description\": \"Encontre restaurantes próximos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"latitude\": {\"type\": \"number\", \"description\": \"A latitude da localização.\"}, \"longitude\": {\"type\": \"number\", \"description\": \"A longitude da localização.\"}, \"radius\": {\"type\": \"integer\", \"description\": \"O raio de pesquisa em metros.\"}}, \"required\": [\"latitude\", \"longitude\", \"radius\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nAtualmente estou nas coordenadas 40.7128 N, 74.0060 W. Você pode encontrar algum restaurante em um raio de 500 metros?",
+      "completion": "<tool_call>\n{\"name\": \"find_nearby_restaurants\", \"arguments\": {\"latitude\": 40.7128, \"longitude\": -74.006, \"radius\": 500}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "find_nearby_restaurants"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_rectangle_area\", \"description\": \"Calcule a área de um retângulo com base em suas dimensões.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"width\": {\"type\": \"number\", \"description\": \"A largura do retângulo.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura do retângulo.\"}}, \"required\": [\"width\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular a área de um retângulo. A largura é 5 unidades e a altura é 10 unidades.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_rectangle_area\", \"arguments\": {\"width\": 5, \"height\": 10}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_rectangle_area"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"body\": {\"type\": \"string\", \"description\": \"O conteúdo corporal do email.\"}}, \"required\": [\"recipient\", \"subject\", \"body\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso enviar um e-mail para o meu chefe. O destinatário é boss@company.com. O assunto deve ser \"Relatório Mensal\" e o corpo deve dizer \"Caro Chefe, Por favor, encontre anexado o relatório mensal para sua avaliação. Atenciosamente, [Usuário].\"",
+      "completion": "<tool_call>\n{\"name\": \"send_email\", \"arguments\": {\"recipient\": \"boss@company.com\", \"subject\": \"Monthly Report\", \"body\": \"Dear Boss, Please find attached the monthly report for your review. Best, [User]\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_random_fact\", \"description\": \"Obtenha um fato aleatório de uma categoria específica.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria do fato.\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEstou entediado. Você pode me contar um fato aleatório sobre o espaço?",
+      "completion": "<tool_call>\n{\"name\": \"get_random_fact\", \"arguments\": {\"category\": \"space\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "get_random_fact"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min\": {\"type\": \"integer\", \"description\": \"O valor mínimo para o número aleatório.\"}, \"max\": {\"type\": \"integer\", \"description\": \"O valor máximo para o número aleatório.\"}}, \"required\": [\"min\", \"max\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu preciso de um número aleatório entre 1 e 100.",
+      "completion": "<tool_call>\n{\"name\": \"generate_random_number\", \"arguments\": {\"min\": 1, \"max\": 100}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOlá, eu vi um vestido que eu realmente gostei. Ele estava originalmente precificado em $200, mas está com um desconto de 20%. Você pode me dizer quanto vai custar após o desconto?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_discount\", \"arguments\": {\"original_price\": 200, \"discount_percentage\": 20}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"A lista de ingredientes.\"}}, \"required\": [\"ingredients\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_qr_code\", \"description\": \"Gerar um código QR para um determinado texto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser codificado no código QR.\"}}, \"required\": [\"text\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nEu tenho um pouco de frango e brócolis sobrando. Você pode me encontrar uma receita que use esses ingredientes?",
+      "completion": "<tool_call>\n{\"name\": \"search_recipes\", \"arguments\": {\"ingredients\": [\"chicken\", \"broccoli\"]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "search_recipes",
+        "generate_qr_code"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_gpa\", \"description\": \"Calcule o GPA (média de notas).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"grades\": {\"type\": \"array\", \"description\": \"Os graus obtidos em diferentes indivíduos.\"}}, \"required\": [\"grades\"]}}}\n{\"type\": \"function\", \"function\": {\"name\": \"generate_barcode\", \"description\": \"Gere uma imagem de código de barras com base nos dados de entrada.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"data\": {\"type\": \"string\", \"description\": \"Os dados a serem codificados no código de barras.\"}}, \"required\": [\"data\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso de ajuda para calcular minha média ponderada. Eu tenho notas para cinco matérias. Elas são 85, 90, 95, 80 e 88.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_gpa\", \"arguments\": {\"grades\": [85, 90, 95, 80, 88]}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_gpa",
+        "generate_barcode"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_bmi\", \"description\": \"Calcule o índice de massa corporal (IMC).\", \"parameters\": {\"type\": \"object\", \"properties\": {\"weight\": {\"type\": \"number\", \"description\": \"O peso em quilogramas.\"}, \"height\": {\"type\": \"number\", \"description\": \"A altura em metros.\"}}, \"required\": [\"weight\", \"height\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, eu preciso calcular meu IMC. Eu peso 75 quilos e minha altura é 1,8 metros.",
+      "completion": "<tool_call>\n{\"name\": \"calculate_bmi\", \"arguments\": {\"weight\": 75, \"height\": 1.8}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_bmi"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_distance\", \"description\": \"Calcule a distância entre dois locais.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"source\": {\"type\": \"string\", \"description\": \"O local da fonte.\"}, \"destination\": {\"type\": \"string\", \"description\": \"O local de destino.\"}}, \"required\": [\"source\", \"destination\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nOi, estou planejando uma viagem de carro. Você pode me dizer a distância entre Nova York e Los Angeles?",
+      "completion": "<tool_call>\n{\"name\": \"calculate_distance\", \"arguments\": {\"source\": \"New York\", \"destination\": \"Los Angeles\"}}\n</tool_call>",
+      "is_valid": true,
+      "tool_names": [
+        "calculate_distance"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"analyze_social_media_sentiment\", \"description\": \"Analise o sentimento de postagens de mídia social.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"posts\": {\"type\": \"array\", \"description\": \"As postagens das mídias sociais a serem analisadas.\"}, \"platform\": {\"type\": \"string\", \"description\": \"A plataforma da qual as postagens são coletadas.\"}}, \"required\": [\"posts\", \"platform\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas como uma IA, não tenho a capacidade de realizar tarefas externas, como pedir uma pizza. Minhas funções são limitadas às que me foram fornecidas, como analisar o sentimento de postagens em redes sociais. Há mais alguma coisa com a qual você precisa de ajuda dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "analyze_social_media_sentiment"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa (título ou autor).\"}, \"limit\": {\"type\": \"integer\", \"description\": \"O número máximo de resultados para retornar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, que neste caso é a busca por livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro baseado em título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atualmente estão limitadas às funções que foram fornecidas, como procurar um livro com base em seu título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_wikipedia\", \"description\": \"Procure um tópico específico na Wikipedia.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"topic\": {\"type\": \"string\", \"description\": \"O tópico a ser pesquisado.\"}}, \"required\": [\"topic\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar um tópico específico na Wikipedia.",
+      "is_valid": false,
+      "tool_names": [
+        "search_wikipedia"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas a procurar livros com base no título, autor ou gênero. Se você precisar de ajuda com isso, fique à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme baseado em título e gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como buscar um filme com base em título e gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir pizza. Minhas capacidades atuais são limitadas às funções que me foram atribuídas, que neste caso é criar uma nota. Há mais alguma coisa com a qual eu possa ajudá-lo dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou autor para procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a buscar livros com base em título ou autor. Eu não tenho a habilidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_stock_price\", \"description\": \"Obtenha o preço atual das ações de uma empresa.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"symbol\": {\"type\": \"string\", \"description\": \"O símbolo de estoque.\"}}, \"required\": [\"symbol\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar informações, como preços de ações. Não tenho a funcionalidade para fazer pedidos de bens ou serviços físicos.",
+      "is_valid": false,
+      "tool_names": [
+        "get_stock_price"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em critérios específicos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, que neste caso é pesquisar livros com base em critérios específicos. Se você precisar de ajuda com isso, sinta-se à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha os detalhes de um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode reservar um ingresso de cinema para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas atuais capacidades permitem que eu busque detalhes sobre um filme com base em seu título e ano. No entanto, não tenho a capacidade de reservar ingressos de cinema, pois isso é uma tarefa externa e nenhuma função foi fornecida para essa tarefa.",
+      "is_valid": false,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em um critério especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atualmente são limitadas às funções que me foram fornecidas, como buscar livros. Há algo mais com o que eu possa ajudar dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_news\", \"description\": \"Pesquise artigos de notícias com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas nos artigos de notícias.\"}, \"max_results\": {\"type\": \"integer\", \"description\": \"O número máximo de resultados para retornar.\"}}, \"required\": [\"keywords\", \"max_results\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas a pesquisar artigos de notícias com base em palavras-chave. Há algo mais com que você gostaria que eu ajudasse dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_news"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é criar uma nota. Se você precisar lembrar de pedir uma pizza mais tarde, posso te ajudar a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar filmes com base em critérios dados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro usando seu título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"book_title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"book_title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar um livro usando seu título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_lyrics\", \"description\": \"Obtenha a letra de uma música.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"song_title\": {\"type\": \"string\", \"description\": \"O título da música.\"}, \"artist\": {\"type\": \"string\", \"description\": \"O artista da música.\"}}, \"required\": [\"song_title\", \"artist\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como recuperar letras de músicas.",
+      "is_valid": false,
+      "tool_names": [
+        "get_lyrics"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"convert_currency\", \"description\": \"Converter um valor de uma moeda para outra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"amount\": {\"type\": \"number\", \"description\": \"O valor para converter.\"}, \"from_currency\": {\"type\": \"string\", \"description\": \"A moeda para converter de.\"}, \"to_currency\": {\"type\": \"string\", \"description\": \"A moeda para se converter.\"}}, \"required\": [\"amount\", \"from_currency\", \"to_currency\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode reservar um voo para mim de Nova Iorque para Londres?",
+      "completion": "Sinto muito, mas não posso ajudar na reserva de voos. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que atualmente incluem conversão de moeda. Recomendo usar um site de reservas de viagens confiável ou entrar em contato diretamente com sua companhia aérea preferida para assistência com reservas de voos.",
+      "is_valid": false,
+      "tool_names": [
+        "convert_currency"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"O conteúdo do email.\"}}, \"required\": [\"recipient\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar essa tarefa. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que neste caso é enviar e-mails. Não tenho a função de pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_number\", \"description\": \"Gerar um número aleatório dentro de um intervalo especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"min_value\": {\"type\": \"number\", \"description\": \"O valor mínimo.\"}, \"max_value\": {\"type\": \"number\", \"description\": \"O valor máximo.\"}}, \"required\": [\"min_value\", \"max_value\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como gerar um número aleatório dentro de um intervalo especificado.",
+      "is_valid": false,
+      "tool_names": [
+        "generate_random_number"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar livros com base no título ou autor. Fazer um pedido de pizza é uma tarefa externa que não estou equipado para lidar, pois não está dentro das funções que me foram fornecidas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a buscar livros com base em título, autor ou gênero. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo executar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"O conteúdo do email.\"}}, \"required\": [\"recipient\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar essa tarefa. A função que me foi fornecida permite que eu envie e-mails. Fazer um pedido de pizza é uma tarefa externa que atualmente não tenho a capacidade de realizar.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_song_lyrics\", \"description\": \"Obtenha a letra de uma música específica.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"song_title\": {\"type\": \"string\", \"description\": \"O título da música.\"}, \"artist_name\": {\"type\": \"string\", \"description\": \"O nome do artista.\"}}, \"required\": [\"song_title\", \"artist_name\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como buscar letras de músicas. Há mais alguma coisa com a qual você precise de ajuda dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "get_song_lyrics"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para traduzir.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para traduzir o texto.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que neste caso é traduzir texto de um idioma para outro. Não tenho a capacidade de realizar tarefas externas, como fazer um pedido de pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Pesquise livros com base nas preferências do usuário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem do livro.\"}}, \"required\": [\"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não sou capaz de realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como pesquisar por livros com base em suas preferências.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"body\": {\"type\": \"string\", \"description\": \"O conteúdo corporal do email.\"}}, \"required\": [\"recipient\", \"subject\", \"body\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar essa tarefa. A função que tenho disponível é para enviar e-mails. Não tenho uma função para pedir pizza ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_password\", \"description\": \"Gerar uma senha aleatória com critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}, \"include_symbols\": {\"type\": \"boolean\", \"description\": \"Inclua símbolos na senha.\"}, \"include_numbers\": {\"type\": \"boolean\", \"description\": \"Inclua números na senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram oferecidas, como gerar uma senha. Se você precisar de ajuda com isso ou qualquer outra função com a qual eu esteja equipado, sinta-se à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "generate_password"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é traduzir texto de um idioma para outro. Não tenho a capacidade de realizar tarefas externas como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"title\", \"author\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas funções estão limitadas às que foram fornecidas, como pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode, por favor, pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar livros com base em título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"Palavras -chave para procurar livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"category\": {\"type\": \"string\", \"description\": \"A categoria do livro.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar livros com base em palavras-chave, autores ou categorias. Se você precisar de ajuda com isso, fique à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a buscar livros com base em palavras-chave e autores. Eu não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título, gênero ou ano de lançamento.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"release_year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode reservar um voo para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com a reserva de voos. Minhas funções atuais só me permitem pesquisar filmes com base no título, gênero ou ano de lançamento. Existe mais alguma coisa com a qual eu possa ajudá-lo dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades são limitadas às funções que me foram fornecidas. Atualmente, posso ajudá-lo a procurar livros por título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_todo\", \"description\": \"Crie um novo item de TODO.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"task\": {\"type\": \"string\", \"description\": \"A descrição da tarefa.\"}, \"due_date\": {\"type\": \"string\", \"description\": \"A data de vencimento da tarefa.\"}}, \"required\": [\"task\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como fazer um pedido de pizza. Posso te ajudar a criar uma tarefa para pedir uma pizza, se você quiser.",
+      "is_valid": false,
+      "tool_names": [
+        "create_todo"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em uma palavra -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar livros com base em uma palavra-chave ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro baseado no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\", \"author\", \"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como buscar um livro com base no título, autor ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem pesquisar livros com base em título ou autor. Não tenho a capacidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_random_quote\", \"description\": \"Gerar uma cotação aleatória de uma coleção.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de citações.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor da citação.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode, por favor, reservar um voo para mim de Nova York para Londres?",
+      "completion": "Sinto muito, mas como uma IA, não tenho a capacidade de reservar voos. Minhas funções são limitadas às que me foram fornecidas. Atualmente, posso gerar uma citação aleatória para você. Você gostaria de ouvir uma citação?",
+      "is_valid": false,
+      "tool_names": [
+        "generate_random_quote"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"play_music\", \"description\": \"Tocar música baseada em artista, álbum ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"artist\": {\"type\": \"string\", \"description\": \"O artista da música.\"}, \"album\": {\"type\": \"string\", \"description\": \"O álbum da música.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero da música.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é tocar música com base em artista, álbum ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "play_music"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero de filmes para pesquisar.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar filmes com base no título ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base nas preferências do usuário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como pesquisar livros com base nas suas preferências.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para o destinatário especificado.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"O conteúdo do email.\"}}, \"required\": [\"recipient\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não consigo realizar essa tarefa. Minhas capacidades atuais são limitadas às funções que me foram atribuídas, que neste caso é enviar e-mails. Não tenho a capacidade de pedir uma pizza para você.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_images\", \"description\": \"Procure imagens.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"Palavras -chave para procurar imagens.\"}, \"color\": {\"type\": \"string\", \"description\": \"A cor das imagens.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades são atualmente limitadas às funções que me foram fornecidas, como procurar imagens com base em palavras-chave e cores específicas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_images"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_music\", \"description\": \"Procure música baseada em artista ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"artist\": {\"type\": \"string\", \"description\": \"O artista da música.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero da música.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento da música.\"}}, \"required\": [\"artist\", \"year\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar músicas com base em artistas ou gêneros.",
+      "is_valid": false,
+      "tool_names": [
+        "search_music"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas como uma IA, eu não tenho a capacidade de realizar tarefas externas, como pedir uma pizza. Minhas funções são limitadas às que me foram atribuídas. Neste caso, posso ajudá-lo a procurar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou ISBN.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram atribuídas, que, neste caso, são pesquisar livros com base no título, autor ou ISBN.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros por título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa\"}, \"search_by\": {\"type\": \"string\", \"description\": \"O campo para pesquisar\"}}, \"required\": [\"query\", \"search_by\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram atribuídas, como procurar livros por título, autor ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_password\", \"description\": \"Gerar uma senha aleatória.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}, \"include_symbols\": {\"type\": \"boolean\", \"description\": \"Inclua símbolos na senha.\"}, \"include_numbers\": {\"type\": \"boolean\", \"description\": \"Inclua números na senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como gerar uma senha. Não tenho a capacidade de realizar tarefas externas, como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "generate_password"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro baseado no título, autor ou ISBN.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a pesquisar livros com base no título, autor ou ISBN. Não tenho a capacidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_recipes\", \"description\": \"Procure receitas com base em ingredientes.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"ingredients\": {\"type\": \"array\", \"description\": \"Os ingredientes para procurar.\"}, \"diet\": {\"type\": \"string\", \"description\": \"A restrição alimentar a considerar, p. vegetariano.\"}}, \"required\": [\"ingredients\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a pesquisar receitas com base em ingredientes e restrições dietéticas. Não tenho a capacidade de fazer pedidos ou realizar tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_recipes"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}, \"actor\": {\"type\": \"string\", \"description\": \"O nome do ator no filme.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar filmes com base em critérios especificados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título do livro ou autor para procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, que neste caso é pesquisar um livro pelo título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\", \"author\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar um livro pelo título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"to\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"body\": {\"type\": \"string\", \"description\": \"O corpo do email.\"}}, \"required\": [\"to\", \"subject\", \"body\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não posso realizar essa tarefa. A função que me foi fornecida é enviar e-mails. Não tenho a capacidade de pedir uma pizza, pois é uma tarefa externa.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a procurar livros com base no título ou autor. Não tenho a capacidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base nos critérios fornecidos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode, por favor, pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, como procurar livros com base em critérios fornecidos. Há mais alguma coisa com a qual posso te ajudar dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news\", \"description\": \"Obtenha as últimas notícias com base na categoria selecionada.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias.\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a fornecer as últimas notícias com base em uma categoria selecionada. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "get_news"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"search_query\": {\"type\": \"string\", \"description\": \"O título ou autor para procurar.\"}}, \"required\": [\"search_query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas. Nesse caso, posso ajudar você a pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que neste caso é criar uma nota. Se você precisar lembrar de pedir uma pizza, posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"O conteúdo do email.\"}}, \"required\": [\"recipient\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim na pizzaria local?",
+      "completion": "Desculpe, mas não consigo realizar essa tarefa. Posso ajudar com tarefas relacionadas às funções que me foram fornecidas, como enviar e-mails. No entanto, fazer um pedido de pizza em uma pizzaria local é uma tarefa externa para a qual não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa (título, autor ou gênero).\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, que neste caso são buscar livros com base no título, autor ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou gênero a procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso são pesquisar filmes com base no título ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em uma consulta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros para procurar.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero dos livros a serem procurados.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar essa tarefa. Minhas funções atuais me permitem buscar livros com base em uma consulta, autor ou gênero. Eu não tenho a capacidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para traduzir o texto.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar essa tarefa. Minhas capacidades atuais são limitadas às funções que me foram atribuídas, como traduzir texto de um idioma para outro. Não tenho a capacidade de fazer pedidos ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"generate_password\", \"description\": \"Gerar uma senha aleatória.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"length\": {\"type\": \"integer\", \"description\": \"A duração da senha.\"}, \"include_special_characters\": {\"type\": \"boolean\", \"description\": \"Inclua caracteres especiais na senha.\"}}, \"required\": [\"length\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como gerar uma senha aleatória. Eu não tenho a capacidade de realizar tarefas externas, como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "generate_password"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro baseado em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a buscar livros com base em palavras-chave, autores ou gêneros. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como criar uma nota.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news_headlines\", \"description\": \"Obtenha as manchetes das últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias (por exemplo, esportes, política, entretenimento).\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não sou capaz de realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como obter as últimas manchetes de notícias. Há algo mais com que você precise de ajuda?",
+      "is_valid": false,
+      "tool_names": [
+        "get_news_headlines"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero dos filmes a serem pesquisados.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento dos filmes.\"}, \"rating\": {\"type\": \"number\", \"description\": \"A classificação mínima dos filmes.\"}}, \"required\": [\"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar filmes com base em critérios especificados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que neste caso é criar uma nota. Se você precisar lembrar de pedir uma pizza, posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, como procurar livros com base no título, autor ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas à pesquisa de livros com base no título ou autor. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano do lançamento do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar um filme. Se você precisar de ajuda com isso ou qualquer outra função que eu tenha, sinta-se à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news\", \"description\": \"Obtenha as manchetes das últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias (por exemplo, esportes, política).\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram proporcionadas, que incluem buscar as últimas manchetes de notícias em várias categorias. Há mais alguma coisa com a qual eu possa te ajudar dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "get_news"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais permitem que eu pesquise títulos de filmes. Pedir uma pizza é uma tarefa externa que não estou equipado para manejar no momento.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem pesquisar filmes pelo título. Pedir uma pizza é uma tarefa externa para a qual não tenho a função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Pesquise filmes com base nas preferências do usuário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como fazer um pedido de pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar filmes com base nas suas preferências.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como fazer um pedido de pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar um filme pelo título.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_music\", \"description\": \"Pesquise álbuns ou músicas de música.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa por música.\"}, \"artist\": {\"type\": \"string\", \"description\": \"O nome do artista.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como buscar músicas. Se precisar de ajuda com isso, fique à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_music"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que atualmente incluem apenas a tradução de texto de um idioma para outro. Não tenho a capacidade de fazer pedidos ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo executar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar filmes. Existe algo mais em que eu possa ajudá-lo dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduza um texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para a tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades são atualmente limitadas às funções que me foram fornecidas, como traduzir texto de um idioma para outro.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"play_music\", \"description\": \"Toque música de um gênero ou artista específico.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero da música para tocar.\"}, \"artist\": {\"type\": \"string\", \"description\": \"O artista cuja música para tocar.\"}}, \"required\": [\"genre\", \"artist\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo ajudar com isso. Minhas funções atuais me permitem tocar música com base em um gênero ou artista específico. Não tenho a função de pedir comida ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "play_music"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que neste caso é criar uma nota. Se você precisar lembrar de pedir uma pizza, posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro por título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a pesquisar livros por título, autor ou gênero. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a pesquisar títulos de filmes. Não tenho uma função para pedir pizza ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"to\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"body\": {\"type\": \"string\", \"description\": \"O corpo do email.\"}}, \"required\": [\"to\", \"subject\", \"body\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem enviar e-mails, mas não tenho a função de pedir uma pizza. Há mais alguma coisa com a qual você precise de ajuda?",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_product\", \"description\": \"Procure um produto com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"As palavras -chave para procurar\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a pesquisar produtos com base em palavras-chave. Não tenho a habilidade de realizar pedidos ou executar tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_product"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, que neste caso são buscar livros com base em título, autor ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em uma palavra -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar filmes com base em uma palavra-chave ou gênero. Pedir uma pizza é uma tarefa externa que não estou preparado para lidar.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"O título ou o nome do autor para pesquisar.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para traduzir.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para traduzir o texto.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que atualmente incluem traduzir texto de um idioma para outro. Não tenho a capacidade de fazer pedidos ou realizar tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar um livro pelo título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas eu não tenho a capacidade de pedir uma pizza para você. Minhas funções são limitadas ao que me é oferecido, e atualmente, eu só posso buscar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"actor\": {\"type\": \"string\", \"description\": \"O ator do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": [\"title\", \"actor\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a procurar filmes com base em critérios especificados, como título, ator e gênero. Não tenho a capacidade de fazer pedidos de comida ou outros itens.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que atualmente incluem pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como traduzir texto de um idioma para outro.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduza um texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem original do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como traduzir texto de uma língua para outra. Não tenho a capacidade de realizar tarefas externas, como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para livros.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem pesquisar livros com base no título ou autor. Não tenho a funcionalidade para fazer pedidos de comida ou outros itens.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_events\", \"description\": \"Procure eventos com base na localização e data.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"A localização do evento.\"}, \"date\": {\"type\": \"string\", \"description\": \"A data do evento.\"}}, \"required\": [\"location\", \"date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar eventos com base na localização e na data.",
+      "is_valid": false,
+      "tool_names": [
+        "search_events"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero dos filmes a serem pesquisados.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento dos filmes.\"}, \"rating\": {\"type\": \"number\", \"description\": \"A classificação mínima dos filmes.\"}}, \"required\": [\"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas a pesquisar filmes com base em critérios específicos, como gênero, ano e avaliação. Não tenho a capacidade de realizar tarefas externas, como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme usando seu título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"movie_title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"movie_title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem pesquisar informações sobre filmes com base no título. Pedir uma pizza é uma tarefa externa para a qual não tenho função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news_headlines\", \"description\": \"Obtenha as manchetes das últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias desejada.\"}, \"country\": {\"type\": \"string\", \"description\": \"O país para manchetes de notícias.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como obter as últimas manchetes de notícias. Há mais alguma coisa em que eu possa te ajudar dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "get_news_headlines"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros para procurar.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como traduzir texto de uma língua para outra.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir texto para outro idioma.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto para traduzir.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas como fazer um pedido de pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como traduzir textos. Se você precisar de ajuda com isso ou qualquer outra função para a qual estou programado, sinta-se à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem procurar títulos de filmes. Não tenho a capacidade de fazer pedidos de comida ou outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar livros com base em palavras-chave.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou autor para procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a pesquisar livros com base no título ou autor. Não tenho a capacidade de pedir comida ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em uma palavra -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram proporcionadas, como buscar livros com base em uma palavra-chave.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor preferido.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como buscar livros com base em palavras-chave. Se você precisar de ajuda com isso ou qualquer outra informação relacionada a livros, fique à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode, por favor, pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como traduzir texto de uma língua para outra. Não tenho a capacidade de realizar tarefas externas, como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base nos critérios fornecidos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como buscar livros com base em critérios dados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em critérios específicos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"Palavras -chave a serem pesquisadas em títulos ou descrições de livros.\"}, \"category\": {\"type\": \"string\", \"description\": \"A categoria de livros para pesquisar.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor dos livros para procurar.\"}}, \"required\": [\"keywords\", \"category\", \"author\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode, por favor, pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a buscar livros com base em critérios específicos, como palavras-chave, categoria e autor. Não tenho a capacidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base nos critérios especificados.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": [\"title\", \"author\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, que neste caso é procurar livros com base em critérios especificados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou gênero a procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, que neste caso é buscar filmes com base no título ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes por título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar filmes.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero para filtrar os filmes.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode reservar um voo para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar filmes por título ou gênero. Não tenho a capacidade de reservar voos, pois é uma tarefa externa e nenhuma função é fornecida para essa tarefa.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_dictionary\", \"description\": \"Procure o significado de uma palavra no dicionário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra a serem pesquisada no dicionário.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas eu não posso ajudar com isso. Minhas capacidades atuais me permitem procurar o significado de uma palavra no dicionário. Pedir uma pizza é uma tarefa externa que eu não estou equipado para lidar.",
+      "is_valid": false,
+      "tool_names": [
+        "search_dictionary"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, como pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"O título ou autor para procurar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar livros com base no título ou autor. Fazer um pedido de pizza é uma tarefa externa para a qual não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas como uma IA, eu não tenho a capacidade de realizar tarefas externas como pedir uma pizza. Minhas funções são limitadas às que me foram fornecidas. Neste caso, posso ajudá-lo a pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, como procurar livros.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou palavra -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa (título, autor ou palavra -chave).\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero de livro preferido.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem do livro preferida.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram oferecidas, como buscar livros. Se você precisar de ajuda com isso ou qualquer outra informação relacionada a livros, sinta-se à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme baseado no título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não sou capaz de realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar um filme com base no título. Se você precisar de ajuda com isso ou com qualquer outra função que eu tenha, fique à vontade para perguntar!",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave para procurar\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é a busca de livros com base em palavras-chave. Há algum livro que você esteja interessado em encontrar?",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_music\", \"description\": \"Procure música baseada em artista ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"artist\": {\"type\": \"string\", \"description\": \"O nome do artista.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero da música.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento da música.\"}}, \"required\": [\"artist\", \"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas funções atuais me permitem buscar músicas com base em artista ou gênero. Não tenho a capacidade de realizar pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_music"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em uma determinada palavra -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar livros com base em uma palavra-chave específica. Pedir uma pizza é uma tarefa externa para a qual eu não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor para filtrar os resultados.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_spelling\", \"description\": \"Verifique a ortografia de uma determinada palavra.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"word\": {\"type\": \"string\", \"description\": \"A palavra para verificar a ortografia de.\"}}, \"required\": [\"word\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é verificar a ortografia de uma palavra.",
+      "is_valid": false,
+      "tool_names": [
+        "check_spelling"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minha capacidade atual me permite buscar livros por título ou autor. Infelizmente, pedir uma pizza é uma tarefa externa para a qual não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você dispõe das seguintes funções para auxiliar na resolução das solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_info\", \"description\": \"Obtenha informações sobre um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode reservar um ingresso para o filme \"A Origem\" para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Embora eu possa fornecer informações sobre o filme \"A Origem\" usando a função \"get_movie_info\", não tenho a capacidade de reservar ingressos para o cinema, pois é uma tarefa externa e nenhuma função foi fornecida para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "get_movie_info"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano do lançamento do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar um filme.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minha função atual me permite criar notas para você. Se você precisar se lembrar de pedir uma pizza mais tarde, posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"check_spelling\", \"description\": \"Verifique a ortografia de uma palavra ou frase.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser verificado.\"}, \"language\": {\"type\": \"string\", \"description\": \"A linguagem do texto.\"}}, \"required\": [\"text\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não sou capaz de realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como verificar a ortografia de uma palavra ou frase.",
+      "is_valid": false,
+      "tool_names": [
+        "check_spelling"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas nos títulos ou descrições de livros.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que atualmente incluem pesquisar livros com base em palavras-chave.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram atribuídas, que neste caso é criar uma nota. Se você precisa lembrar de pedir uma pizza, posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para filmes.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso são pesquisar filmes com base no título ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\", \"author\", \"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a buscar livros com base em título, autor ou gênero. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa para livros.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem procurar livros com base no título ou autor. Fazer um pedido de pizza é uma tarefa externa para a qual não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a buscar livros com base no título, autor ou gênero. Eu não tenho a função de pedir pizza ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem à sua disposição as funções descritas abaixo para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_flight_status\", \"description\": \"Obtenha o status de um voo.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"flight_number\": {\"type\": \"string\", \"description\": \"O número do voo.\"}, \"date\": {\"type\": \"string\", \"description\": \"A data do voo.\"}}, \"required\": [\"flight_number\", \"date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode reservar um voo para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais permitem que eu obtenha o status de um voo dado o número do voo e a data. No entanto, não tenho a habilidade de reservar voos, pois é uma tarefa externa e nenhuma função foi fornecida para essa tarefa.",
+      "is_valid": false,
+      "tool_names": [
+        "get_flight_status"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"make_note\", \"description\": \"Fazer uma anotação.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minha função atual me permite fazer anotações para você. Se você precisar se lembrar de pedir uma pizza, posso ajudá-lo a fazer uma anotação sobre isso.",
+      "is_valid": false,
+      "tool_names": [
+        "make_note"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar no título ou autor do livro.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas à busca por livros com base no título ou autor. Não tenho a capacidade de fazer pedidos de itens externos, como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso às seguintes ferramentas para auxiliar o usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news\", \"description\": \"Obtenha as últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias para recuperar.\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas atuais capacidades estão limitadas às funções que me foram fornecidas, como recuperar as últimas notícias em uma categoria específica.",
+      "is_valid": false,
+      "tool_names": [
+        "get_news"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em uma palavra -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas eu não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a procurar livros com base em uma palavra-chave. Eu não tenho a capacidade de pedir pizza ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir pizza. Minha função atual me permite criar notas para você. Se você precisar se lembrar de pedir pizza mais tarde, posso criar uma nota para você.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_todo_list\", \"description\": \"Crie uma nova lista de TODO.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"list_name\": {\"type\": \"string\", \"description\": \"O nome da lista de TODO.\"}}, \"required\": [\"list_name\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades atuais são limitadas às funções que me foram atribuídas, que neste caso é criar uma lista de tarefas.",
+      "is_valid": false,
+      "tool_names": [
+        "create_todo_list"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes baseados no título e gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}}, \"required\": [\"title\", \"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar filmes com base em título e gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient_email\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"message\": {\"type\": \"string\", \"description\": \"O conteúdo do email.\"}}, \"required\": [\"recipient_email\", \"subject\", \"message\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram fornecidas, que neste caso são o envio de um e-mail.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas às funções que me foram fornecidas. Neste caso, posso ajudá-lo a criar uma nota. Pedir uma pizza é uma tarefa externa para a qual não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}, \"category\": {\"type\": \"string\", \"description\": \"A categoria da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas como uma IA, não sou capaz de realizar tarefas externas como pedir uma pizza. Minha função atual me permite criar notas para você. Se você precisar lembrar de pedir uma pizza, certamente posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "Você pode chamar uma ou mais das funções a seguir para ajudar a responder à solicitação do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_images\", \"description\": \"Pesquise imagens com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"color\": {\"type\": \"string\", \"description\": \"O filtro de cores para as imagens.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a buscar imagens com base em palavras-chave. Não tenho a capacidade de fazer pedidos ou realizar tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_images"
+      ]
+    },
+    {
+      "prompt": "## Funções disponíveis\n\nUtilize as funções abaixo conforme necessário para responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\", \"author\", \"genre\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como fazer um pedido de pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, como pesquisar livros com base em critérios especificados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como buscar livros com base em critérios determinados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"calculate_discount\", \"description\": \"Calcule o preço com desconto.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"original_price\": {\"type\": \"number\", \"description\": \"O preço original do item.\"}, \"discount_percentage\": {\"type\": \"number\", \"description\": \"A porcentagem de desconto.\"}}, \"required\": [\"original_price\", \"discount_percentage\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como calcular descontos. Existe algo mais com que você precise de ajuda dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "calculate_discount"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em parâmetros.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas a buscar livros com base em título, autor ou gênero. Não tenho a capacidade de fazer pedidos de itens externos como pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_images\", \"description\": \"Pesquise imagens com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"limit\": {\"type\": \"integer\", \"description\": \"O número máximo de imagens para recuperar.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas a procurar imagens com base em palavras-chave. Existe mais alguma coisa com a qual eu possa ajudá-lo dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_images"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_images\", \"description\": \"Pesquise imagens com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave para pesquisa de imagem.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais são limitadas às funções que me foram proporcionadas, como buscar imagens com base em palavras-chave. Há algo mais com que eu possa ajudar dentro das minhas capacidades?",
+      "is_valid": false,
+      "tool_names": [
+        "search_images"
+      ]
+    },
+    {
+      "prompt": "## Tools\n\nAs ferramentas a seguir estão disponíveis para você usar ao responder às consultas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_book\", \"description\": \"Procure um livro por título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"search_query\": {\"type\": \"string\", \"description\": \"O título ou autor do livro.\"}}, \"required\": [\"search_query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, como procurar um livro pelo título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_book"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas nos títulos de livros.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor para filtrar os livros.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode, por favor, pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atualmente estão limitadas às funções que me foram fornecidas, como pesquisar livros com base em palavras-chave ou por autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_movie_details\", \"description\": \"Obtenha detalhes sobre um filme.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"movie_title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"movie_title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem fornecer informações sobre filmes. Não tenho a capacidade de realizar tarefas externas como pedir uma pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "get_movie_details"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como buscar livros com base em título, autor ou gênero.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_task\", \"description\": \"Crie uma tarefa em uma lista de tarefas.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da tarefa.\"}, \"due_date\": {\"type\": \"string\", \"description\": \"A data de vencimento da tarefa.\"}, \"priority\": {\"type\": \"string\", \"description\": \"O nível de prioridade da tarefa.\"}}, \"required\": [\"title\", \"due_date\", \"priority\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades são limitadas às funções que me foram dadas, e pedir uma pizza é uma tarefa externa para a qual não tenho uma função. Posso ajudá-lo a criar uma tarefa em sua lista de afazeres para pedir uma pizza, se isso for útil.",
+      "is_valid": false,
+      "tool_names": [
+        "create_task"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes baseados em gênero e ano.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"genre\", \"year\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais são limitadas à busca de filmes com base em gênero e ano. Não tenho a habilidade de realizar tarefas externas como pedir pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "As seguintes funções estão disponíveis para uso. Chame-as quando precisar para responder ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes baseados no título, ator ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"search_query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa (título, ator ou gênero).\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento dos filmes.\"}, \"rating\": {\"type\": \"number\", \"description\": \"A classificação mínima dos filmes.\"}}, \"required\": [\"search_query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais estão limitadas a pesquisar filmes com base no título, ator ou gênero. Não tenho a capacidade de fazer pedidos de comida ou outros itens.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave para procurar\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minha função disponível é pesquisar livros com base em palavras-chave. Há mais alguma coisa com a qual eu possa ajudar você?",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode invocar qualquer uma das seguintes funções para auxiliar na resposta ao usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_calendar_event\", \"description\": \"Crie um novo evento no calendário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do evento.\"}, \"start_time\": {\"type\": \"string\", \"description\": \"A hora de início do evento.\"}, \"end_time\": {\"type\": \"string\", \"description\": \"O horário final do evento.\"}}, \"required\": [\"title\", \"start_time\", \"end_time\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não consigo realizar essa tarefa. Minhas funções atuais só me permitem criar eventos em um calendário. Não tenho a capacidade de fazer pedidos ou interagir com serviços externos.",
+      "is_valid": false,
+      "tool_names": [
+        "create_calendar_event"
+      ]
+    },
+    {
+      "prompt": "# Tools\n\nHá várias funções disponíveis que você pode invocar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_note\", \"description\": \"Crie uma nova nota.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da nota.\"}, \"content\": {\"type\": \"string\", \"description\": \"O conteúdo da nota.\"}}, \"required\": [\"title\", \"content\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram atribuídas, que neste caso é criar uma nota. Se você precisar lembrar de pedir uma pizza mais tarde, posso ajudá-lo a criar uma nota para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "create_note"
+      ]
+    },
+    {
+      "prompt": "As funções abaixo estão disponíveis para uso. Utilize-as conforme necessário para responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"translate_text\", \"description\": \"Traduzir o texto de um idioma para outro.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"text\": {\"type\": \"string\", \"description\": \"O texto a ser traduzido.\"}, \"source_language\": {\"type\": \"string\", \"description\": \"A linguagem de origem do texto.\"}, \"target_language\": {\"type\": \"string\", \"description\": \"O idioma de destino para a tradução.\"}}, \"required\": [\"text\", \"source_language\", \"target_language\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram atribuídas, que neste caso são traduzir texto de uma língua para outra.",
+      "is_valid": false,
+      "tool_names": [
+        "translate_text"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"create_task\", \"description\": \"Crie uma nova tarefa.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título da tarefa.\"}, \"due_date\": {\"type\": \"string\", \"description\": \"A data de vencimento da tarefa.\"}, \"priority\": {\"type\": \"string\", \"description\": \"A prioridade da tarefa.\"}}, \"required\": [\"title\", \"due_date\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Desculpe, mas eu não posso ajudar com isso. Minhas capacidades são limitadas às funções que me foram fornecidas. Atualmente, posso ajudá-lo a criar tarefas com um título, data de entrega e prioridade. Pedir uma pizza é uma tarefa externa que eu não estou equipado para lidar.",
+      "is_valid": false,
+      "tool_names": [
+        "create_task"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do livro.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo realizar tarefas externas, como fazer um pedido de pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é procurar livros com base em critérios dados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em critérios específicos.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"author\": {\"type\": \"string\", \"description\": \"O autor dos livros\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero dos livros\"}, \"publication_year\": {\"type\": \"integer\", \"description\": \"O ano de publicação dos livros\"}}, \"required\": [\"author\", \"genre\", \"publication_year\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem pesquisar livros com base em critérios específicos, como autor, gênero e ano de publicação. Pedir uma pizza é uma tarefa externa para a qual não tenho uma função.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_images\", \"description\": \"Procure imagens com base em uma consulta.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}, \"limit\": {\"type\": \"integer\", \"description\": \"O número máximo de imagens para recuperar.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não posso realizar tarefas externas como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso é pesquisar imagens com base em uma consulta.",
+      "is_valid": false,
+      "tool_names": [
+        "search_images"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"get_news_headlines\", \"description\": \"Obtenha as manchetes das últimas notícias.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"category\": {\"type\": \"string\", \"description\": \"A categoria de notícias, p. negócios, esportes\"}}, \"required\": [\"category\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar as últimas manchetes de notícias com base na categoria que você fornecer. Não tenho a função de pedir uma pizza ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "get_news_headlines"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a buscar livros com base em título ou autor. Não tenho uma função para pedir pizza ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_image\", \"description\": \"Pesquise imagens relacionadas a uma palavra -chave específica.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar.\"}, \"color\": {\"type\": \"string\", \"description\": \"O filtro de cores para as imagens.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem pesquisar por imagens com base em palavras-chave específicas. Não tenho a funcionalidade para fazer pedidos de comida ou outros itens.",
+      "is_valid": false,
+      "tool_names": [
+        "search_image"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": []}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim, por favor?",
+      "completion": "Sinto muito, mas não consigo ajudar com isso. Minhas capacidades atuais são limitadas à busca de filmes com base em critérios fornecidos, como título, gênero e ano de lançamento. Não tenho a função de pedir comida ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "Você tem acesso a ferramentas que podem ser chamadas para auxiliar nas respostas. As funções disponíveis são:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base no título ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keyword\": {\"type\": \"string\", \"description\": \"A palavra -chave a procurar nos filmes.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero a procurar.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento para filtrar.\"}}, \"required\": [\"keyword\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso executar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como procurar filmes.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "# Ferramentas disponíveis\n\nVocê pode chamar as funções listadas abaixo para auxiliar na consulta do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base em palavras -chave.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"array\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O nome do autor.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais me permitem buscar livros com base em palavras-chave ou nome do autor. Há mais alguma coisa com que você precise de ajuda relacionada à busca de livros?",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "Você pode usar as funções abaixo para ajudar a atender às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movies\", \"description\": \"Pesquise filmes com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do filme.\"}, \"year\": {\"type\": \"integer\", \"description\": \"O ano de lançamento do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas como fazer pedidos de pizza. Minhas capacidades estão atualmente limitadas às funções que me foram fornecidas, como pesquisar filmes com base em critérios dados.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movies"
+      ]
+    },
+    {
+      "prompt": "## Funções\n\nAs seguintes funções estão à sua disposição para responder às solicitações do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Procure livros com base em determinados critérios.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"keywords\": {\"type\": \"string\", \"description\": \"As palavras -chave a serem pesquisadas.\"}, \"author\": {\"type\": \"string\", \"description\": \"O autor do livro.\"}, \"genre\": {\"type\": \"string\", \"description\": \"O gênero do livro.\"}}, \"required\": [\"keywords\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não consigo realizar tarefas externas, como pedir uma pizza. Minhas capacidades estão atualmente limitadas às funções que me foram atribuídas, que neste caso consistem em buscar livros com base em critérios fornecidos.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser invocadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_movie\", \"description\": \"Procure um filme por título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"title\": {\"type\": \"string\", \"description\": \"O título do filme.\"}}, \"required\": [\"title\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso ajudar com isso. Minhas capacidades estão atualmente limitadas a buscar títulos de filmes. Não tenho a habilidade de realizar tarefas externas, como fazer um pedido de pizza.",
+      "is_valid": false,
+      "tool_names": [
+        "search_movie"
+      ]
+    },
+    {
+      "prompt": "## Ferramentas\n\nExistem funções disponíveis que você pode usar para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"send_email\", \"description\": \"Envie um email para um destinatário.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"recipient\": {\"type\": \"string\", \"description\": \"O endereço de e -mail do destinatário.\"}, \"subject\": {\"type\": \"string\", \"description\": \"O assunto do email.\"}, \"body\": {\"type\": \"string\", \"description\": \"O conteúdo corporal do email.\"}}, \"required\": [\"recipient\", \"subject\", \"body\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. A função que tenho disponível é para enviar e-mails. Não tenho a capacidade de pedir uma pizza, pois é uma tarefa externa e nenhuma função foi fornecida para isso.",
+      "is_valid": false,
+      "tool_names": [
+        "send_email"
+      ]
+    },
+    {
+      "prompt": "Estão disponíveis as seguintes funções, que você pode invocar para responder ao usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_jobs\", \"description\": \"Procure empregos com base na localização, indústria ou título.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"location\": {\"type\": \"string\", \"description\": \"A localização do trabalho.\"}, \"industry\": {\"type\": \"string\", \"description\": \"A indústria do trabalho.\"}, \"title\": {\"type\": \"string\", \"description\": \"O cargo.\"}}, \"required\": [\"location\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não sou capaz de realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, como pesquisar vagas de emprego com base em localização, setor ou cargo.",
+      "is_valid": false,
+      "tool_names": [
+        "search_jobs"
+      ]
+    },
+    {
+      "prompt": "Quando necessário, você pode chamar as seguintes funções para responder às perguntas do usuário:\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título, autor ou gênero.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"search_query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa (título, autor ou gênero).\"}, \"limit\": {\"type\": \"integer\", \"description\": \"O número máximo de resultados para retornar.\"}}, \"required\": [\"search_query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Sinto muito, mas não posso ajudar com isso. Minhas capacidades atuais me permitem buscar livros com base no título, autor ou gênero. Eu não tenho a habilidade de pedir comida ou realizar outras tarefas externas.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    },
+    {
+      "prompt": "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções que podem ser usadas para ajudar a responder às perguntas do usuário.\n\nVocê recebe assinaturas de funções dentro de tags XML <tools></tools>:\n<tools>\n{\"type\": \"function\", \"function\": {\"name\": \"search_books\", \"description\": \"Pesquise livros com base no título ou autor.\", \"parameters\": {\"type\": \"object\", \"properties\": {\"query\": {\"type\": \"string\", \"description\": \"A consulta de pesquisa.\"}}, \"required\": [\"query\"]}}}\n</tools>\n\nPara cada chamada de função, retorne um objeto json com o nome da função e os argumentos dentro das tags XML <tool_call></tool_call>:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>\n\nVocê pode pedir uma pizza para mim?",
+      "completion": "Desculpe, mas não posso realizar tarefas externas, como pedir uma pizza. Minhas capacidades atuais estão limitadas às funções que me foram fornecidas, que neste caso são pesquisar livros com base no título ou autor.",
+      "is_valid": false,
+      "tool_names": [
+        "search_books"
+      ]
+    }
+  ]
+}

--- a/gym/generate_from_email_templates.py
+++ b/gym/generate_from_email_templates.py
@@ -14,7 +14,7 @@ Two categories of fields are supported:
       date, attachments, spam, sender_email, telephone_number
 
 For injected fields an explicit metadata header is prepended to the email
-text, and a corresponding ``email:field_value`` verifier is added so the
+text, and a corresponding `email:field_value` verifier is added so the
 extraction can be verified exactly.
 
 Usage:
@@ -38,7 +38,6 @@ from pathlib import Path
 
 from tasks_metadata import (
     EMAIL_ALL_FIELDS,
-    EMAIL_DIRECT_FIELDS,
     EMAIL_INJECTED_FIELDS,
     EMAIL_FIELD_LABELS,
     EMAIL_TASK_IDS,
@@ -60,19 +59,16 @@ _PROMPT_PREAMBLES = [
 _FORMAT_INSTRUCTION = (
     "Formate sua resposta EXATAMENTE como um bloco JSON markdown, "
     "sem nenhum texto antes ou depois:\n"
-    "```json\n"
+    "``json\n"
     "{\n"
     "  ...\n"
     "}\n"
-    "```\n"
+    "``\n"
     "O JSON deve conter SOMENTE as chaves solicitadas, sem campos adicionais."
 )
 
 
-# ---------------------------------------------------------------------------
 # Random value generators for injected fields
-# ---------------------------------------------------------------------------
-
 _EMAIL_DOMAINS = [
     "gmail.com",
     "yahoo.com.br",
@@ -192,7 +188,7 @@ def build_email_sample(email_text, key, fields, injected_values, rng):
         key: Integer identifier for this sample.
         fields: List of field names to request in the output JSON.
         injected_values: Dict of all five injected field values.
-        rng: ``random.Random`` instance for reproducibility.
+        rng: `random.Random` instance for reproducibility.
 
     Returns:
         Dict with keys: key, prompt, verifier_id_list, kwargs.
@@ -291,7 +287,7 @@ def sample_fingerprint(sample):
 def load_emails(emails_file):
     """Load emails from a JSONL file.
 
-    Each line must be a JSON object with an ``"email"`` key.
+    Each line must be a JSON object with an `"email"` key.
     Returns a list of email strings.
     """
     path = Path(emails_file)

--- a/gym/generate_from_tool_call_templates.py
+++ b/gym/generate_from_tool_call_templates.py
@@ -1,0 +1,744 @@
+"""
+Procedural generator for tool-calling tasks.
+
+Reads `tools.json` (tool definitions and examples)
+and produces new gym-format samples covering:
+
+  1. Valid tool-call tasks: model should produce `<tool_call>...</tool_call>`
+  2. Refusal tasks: model should explain why no tool applies
+
+Usage:
+    python generate_from_tool_call_templates.py \
+        --output_file tool_call_tasks.jsonl \
+        --num_samples 500
+
+    python generate_from_tool_call_templates.py \
+        --output_file tool_call_tasks.json \
+        --num_samples 1000 \
+        --min_tools 1 --max_tools 3 \
+        --refusal_ratio 0.5 \
+        --seed 42 --start_key 0 --verbose
+"""
+
+import json
+import random
+import argparse
+from pathlib import Path
+
+from tasks_metadata import (
+    TOOL_CALL_TASK_IDS,
+)
+
+_DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+# Prompt system preambles (Portuguese, varied styles)
+_SYSTEM_PREAMBLES = [
+    (
+        "Você pode chamar uma ou mais das funções a seguir para ajudar "
+        "a responder à solicitação do usuário."
+    ),
+    (
+        "As funções abaixo estão disponíveis para uso. Utilize-as conforme "
+        "necessário para responder às perguntas do usuário."
+    ),
+    (
+        "Você tem acesso a ferramentas que podem ser chamadas para auxiliar "
+        "nas respostas. As funções disponíveis são:"
+    ),
+    (
+        "## Ferramentas\n\n"
+        "Existem funções disponíveis que você pode usar para ajudar a "
+        "responder às perguntas do usuário."
+    ),
+    (
+        "## Tools\n\nAs ferramentas a seguir estão disponíveis para você "
+        "usar ao responder às consultas do usuário."
+    ),
+    (
+        "As seguintes funções estão disponíveis para uso. Chame-as quando "
+        "precisar para responder ao usuário."
+    ),
+    (
+        "# Ferramentas disponíveis\n\n"
+        "Você pode chamar as funções listadas abaixo para auxiliar "
+        "na consulta do usuário."
+    ),
+    (
+        "## Funções\n\nAs seguintes funções estão à sua disposição para "
+        "responder às solicitações do usuário."
+    ),
+    (
+        "Estão disponíveis as seguintes funções, que você pode invocar "
+        "para responder ao usuário."
+    ),
+    (
+        "# Ferramentas\n\nVocê pode usar as ferramentas listadas abaixo "
+        "para auxiliar na consulta do usuário."
+    ),
+    (
+        "Quando necessário, você pode chamar as seguintes funções para "
+        "responder às perguntas do usuário."
+    ),
+    (
+        "## Funções disponíveis\n\nUtilize as funções abaixo conforme "
+        "necessário para responder às consultas do usuário."
+    ),
+    (
+        "# Tools / Ferramentas\n\nAs funções listadas abaixo podem ser "
+        "invocadas para ajudar a responder às perguntas do usuário."
+    ),
+    (
+        "# Tools / Ferramentas\n\nVocê tem acesso a uma série de funções "
+        "que podem ser usadas para ajudar a responder às perguntas."
+    ),
+]
+
+_TOOL_CALL_INSTRUCTION = (
+    "Para cada chamada de função, retorne um objeto json com o nome da "
+    "função e os argumentos dentro das tags XML <tool_call></tool_call>:\n"
+    "<tool_call>\n"
+    '{"name": <function-name>, "arguments": <args-json-object>}\n'
+    "</tool_call>"
+)
+
+
+# User query templates for VALID tasks (tool is applicable)
+#
+# Each template group targets a tool category.  `{slots}` are filled
+# from the tool's parameter descriptions at generation time.
+
+_VALID_QUERY_TEMPLATES = {
+    "calculate": [
+        "Oi, preciso calcular {description_hint}. Pode me ajudar?",
+        "Olá! Gostaria que você calculasse {description_hint} para mim.",
+        "Preciso de ajuda com um cálculo: {description_hint}.",
+        "Você poderia me ajudar a calcular {description_hint}?",
+        "Pode fazer o cálculo de {description_hint}?",
+    ],
+    "get": [
+        "Oi, você pode me dar informações sobre {description_hint}?",
+        "Gostaria de saber sobre {description_hint}.",
+        "Preciso de informações sobre {description_hint}. Pode me ajudar?",
+        "Me diga sobre {description_hint}, por favor.",
+        "Olá! Você poderia buscar {description_hint} para mim?",
+    ],
+    "search": [
+        "Preciso pesquisar {description_hint}. Pode me ajudar?",
+        "Gostaria de pesquisar {description_hint}.",
+        "Pode buscar informações sobre {description_hint}?",
+        "Me ajude a encontrar {description_hint}, por favor.",
+        "Olá! Quero buscar {description_hint}.",
+    ],
+    "analyze": [
+        "Preciso analisar {description_hint}. Pode me ajudar?",
+        "Gostaria de fazer uma análise de {description_hint}.",
+        "Você poderia analisar {description_hint} para mim?",
+        "Preciso de uma análise sobre {description_hint}.",
+        "Me ajude a analisar {description_hint}, por favor.",
+    ],
+    "create": [
+        "Preciso criar {description_hint}. Pode me ajudar?",
+        "Gostaria de gerar {description_hint}.",
+        "Você poderia criar {description_hint} para mim?",
+        "Me ajude a criar {description_hint}, por favor.",
+        "Oi, preciso que você crie {description_hint}.",
+    ],
+    "convert": [
+        "Preciso converter {description_hint}. Pode me ajudar?",
+        "Gostaria de fazer uma conversão de {description_hint}.",
+        "Você poderia converter {description_hint} para mim?",
+        "Me ajude a converter {description_hint}, por favor.",
+        "Oi, preciso de uma conversão: {description_hint}.",
+    ],
+    "generic": [
+        "Oi, {description_hint}. Pode me ajudar?",
+        "Olá! Preciso de ajuda com o seguinte: {description_hint}.",
+        "Gostaria de {description_hint}.",
+        "Você poderia me ajudar com {description_hint}?",
+        "Preciso de ajuda: {description_hint}.",
+        "Oi, estou precisando de {description_hint}. Pode me ajudar?",
+        "Olá, preciso que você faça {description_hint} para mim.",
+    ],
+}
+
+
+# User query templates for REFUSAL tasks (no tool applies)
+
+_REFUSAL_QUERY_TEMPLATES = [
+    "Você pode pedir uma pizza para mim, por favor?",
+    "Pode me recomendar um bom restaurante?",
+    "Gostaria que você marcasse uma consulta médica para mim.",
+    "Pode ligar para meu amigo e dar um recado?",
+    "Preciso que você compre passagens aéreas para mim.",
+    "Pode escrever e enviar um e-mail para meu chefe?",
+    "Gostaria que você fizesse uma reserva em um hotel.",
+    "Pode me contar uma piada?",
+    "Gostaria de ouvir uma música. Pode tocar algo?",
+    "Pode me dar um abraço virtual?",
+    "Preciso de ajuda para arrumar minha casa.",
+    "Você pode cozinhar algo para mim?",
+    "Gostaria que você me ajudasse a dormir melhor.",
+    "Pode me ensinar a dirigir?",
+    "Preciso que você cuide do meu cachorro.",
+    "Pode me ajudar a mudar de casa?",
+    "Gostaria que você fosse ao supermercado para mim.",
+    "Pode me dar conselhos sobre relacionamentos?",
+    "Preciso que você conserte meu computador.",
+    "Pode me ajudar a pintar a parede da sala?",
+    "Gostaria que você me ensinasse a nadar.",
+    "Pode me ajudar a escolher um presente de aniversário?",
+    "Preciso que você lave meu carro.",
+    "Pode me ajudar a organizar minha festa?",
+    "Gostaria que você me dissesse o futuro.",
+    "Pode me ajudar a encontrar um emprego?",
+    "Preciso que você faça uma entrega para mim.",
+    "Pode me ajudar a decorar minha casa?",
+    "Gostaria que você me preparasse para uma entrevista.",
+    "Pode me ajudar com minha mudança de visual?",
+    "Quanto custa um apartamento no centro de São Paulo?",
+    "Qual é o melhor time de futebol do Brasil?",
+    "Pode me dizer como está o trânsito agora?",
+    "Preciso de ajuda para montar um móvel.",
+    "Pode me recomendar um filme para hoje à noite?",
+    "Gostaria que você me acordasse amanhã às 7h.",
+    "Pode me ajudar a aprender a tocar violão?",
+    "Preciso que você me ajude a traduzir uma conversa ao vivo.",
+    "Pode me ajudar a criar um perfil de namoro?",
+    "Gostaria que você me ajudasse a treinar para uma maratona.",
+]
+
+
+
+# Data loading
+def load_tool_call_data(path):
+    """Load the merged tool-call data file.
+
+    Returns (tools, examples) where tools is a list of tool-schema dicts
+    and examples is a list of example dicts.
+    """
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    tools = [t for t in data["tools"] if t.get("function", {}).get("name")]
+    examples = data.get("examples", [])
+    return tools, examples
+
+
+# Keep for backwards compat / tests
+def load_tools(path):
+    """Load tool definitions from a JSON file (legacy helper)."""
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict) and "tools" in data:
+        items = data["tools"]
+    else:
+        items = data
+    return [t for t in items if t.get("function", {}).get("name")]
+
+
+def _tools_by_name(tools):
+    """Build a name→tool dict for quick lookup."""
+    return {t["function"]["name"]: t for t in tools}
+
+
+
+# Argument generation helpers
+_EXAMPLE_VALUES = {
+    "string": [
+        "exemplo", "teste", "São Paulo", "Rio de Janeiro",
+        "Nova York", "hoje", "amanhã", "importante", "urgente",
+        "relatório mensal", "João", "Maria", "2024-01-15",
+    ],
+    "number": [10, 25, 50, 100, 3.14, 9.99, 42, 0.5, 1000, 250],
+    "integer": [1, 2, 3, 5, 10, 15, 20, 25, 50, 100],
+    "boolean": [True, False],
+    "array": [
+        ["item1", "item2"],
+        ["a", "b", "c"],
+        ["primeiro", "segundo", "terceiro"],
+    ],
+}
+
+
+def _generate_arg_value(param_schema, rng):
+    """Generate a plausible argument value based on the JSON schema type."""
+    ptype = param_schema.get("type", "string")
+
+    if ptype == "string":
+        desc = param_schema.get("description", "").lower()
+        # Try to generate contextual values based on description
+        if any(w in desc for w in ["data", "date", "nascimento"]):
+            return f"{rng.randint(1980, 2005)}-{rng.randint(1,12):02d}-{rng.randint(1,28):02d}"
+        if any(w in desc for w in ["nome", "name", "título", "title"]):
+            names = ["João Silva", "Maria Santos", "O Poderoso Chefão",
+                     "Ana Costa", "Pedro Lima", "Interstellar"]
+            return rng.choice(names)
+        if any(w in desc for w in ["local", "cidade", "location", "destino", "origem"]):
+            places = ["São Paulo", "Rio de Janeiro", "Nova York",
+                      "Londres", "Tokyo", "Lisboa", "Paris"]
+            return rng.choice(places)
+        if any(w in desc for w in ["moeda", "currency"]):
+            currencies = ["USD", "BRL", "EUR", "GBP", "JPY"]
+            return rng.choice(currencies)
+        if any(w in desc for w in ["idioma", "language", "língua"]):
+            langs = ["Português", "Inglês", "Espanhol", "Francês"]
+            return rng.choice(langs)
+        return rng.choice(_EXAMPLE_VALUES["string"])
+    elif ptype in ("number", "integer"):
+        return rng.choice(_EXAMPLE_VALUES.get(ptype, [42]))
+    elif ptype == "boolean":
+        return rng.choice([True, False])
+    elif ptype == "array":
+        return rng.choice(_EXAMPLE_VALUES["array"])
+    elif ptype == "object":
+        return {"chave": "valor"}
+    return "valor_exemplo"
+
+
+def generate_tool_arguments(tool, rng):
+    """Generate argument values for all required + some optional params.
+
+    Returns dict of argument name → value.
+    """
+    params = tool["function"].get("parameters", {})
+    properties = params.get("properties", {})
+    required = set(params.get("required", []))
+    args = {}
+    for name, schema in properties.items():
+        if name in required or rng.random() < 0.5:
+            args[name] = _generate_arg_value(schema, rng)
+    # Always include at least required params
+    for name in required:
+        if name not in args:
+            schema = properties.get(name, {"type": "string"})
+            args[name] = _generate_arg_value(schema, rng)
+    return args
+
+
+def get_tool_arg_types(tool):
+    """Extract expected JSON types for each parameter from the tool schema."""
+    params = tool["function"].get("parameters", {})
+    properties = params.get("properties", {})
+    return {name: schema.get("type", "string") for name, schema in properties.items()}
+
+
+
+# Prompt construction
+def _format_tools_block(tools):
+    """Serialize tools into the <tools>...</tools> XML block for the prompt."""
+    lines = []
+    for t in tools:
+        lines.append(json.dumps(t, ensure_ascii=False))
+    return "\n".join(lines)
+
+
+def _categorize_tool(tool_name):
+    """Return the best query-template category for a tool name."""
+    name_lower = tool_name.lower()
+    for cat in ("calculate", "get", "search", "analyze", "create", "convert"):
+        if cat in name_lower:
+            return cat
+    return "generic"
+
+
+def _build_description_hint(tool):
+    """Create a natural-language hint from the tool's description and params."""
+    desc = tool["function"].get("description", "")
+    if desc:
+        # Lower-case the first letter for natural embedding in a sentence
+        hint = desc[0].lower() + desc[1:] if len(desc) > 1 else desc.lower()
+        # Strip trailing period
+        hint = hint.rstrip(".")
+        return hint
+    return tool["function"]["name"].replace("_", " ")
+
+
+def build_valid_prompt(tool, rng, extra_tools=None):
+    """Build a full prompt for a valid tool-call task.
+
+    Args:
+        tool: The target tool that should be called.
+        rng: Random instance.
+        extra_tools: Optional list of additional distractor tools.
+
+    Returns:
+        The complete prompt string.
+    """
+    preamble = rng.choice(_SYSTEM_PREAMBLES)
+
+    # Build the tool set: target + optional distractors
+    prompt_tools = [tool]
+    if extra_tools:
+        prompt_tools.extend(extra_tools)
+    rng.shuffle(prompt_tools)
+
+    tools_block = _format_tools_block(prompt_tools)
+    category = _categorize_tool(tool["function"]["name"])
+    templates = _VALID_QUERY_TEMPLATES.get(category, _VALID_QUERY_TEMPLATES["generic"])
+    hint = _build_description_hint(tool)
+    user_query = rng.choice(templates).format(description_hint=hint)
+
+    prompt = (
+        f"{preamble}\n\n"
+        f"Você recebe assinaturas de funções dentro de tags XML "
+        f"<tools></tools>:\n<tools>\n{tools_block}\n</tools>\n\n"
+        f"{_TOOL_CALL_INSTRUCTION}\n\n"
+        f"{user_query}"
+    )
+    return prompt, prompt_tools
+
+
+def build_refusal_prompt(distractor_tools, rng):
+    """Build a full prompt for a refusal task.
+
+    The user asks something that no provided tool can handle.
+
+    Args:
+        distractor_tools: Tools to include (none will match the query).
+        rng: Random instance.
+
+    Returns:
+        The complete prompt string.
+    """
+    preamble = rng.choice(_SYSTEM_PREAMBLES)
+    tools_block = _format_tools_block(distractor_tools)
+    user_query = rng.choice(_REFUSAL_QUERY_TEMPLATES)
+
+    prompt = (
+        f"{preamble}\n\n"
+        f"Você recebe assinaturas de funções dentro de tags XML "
+        f"<tools></tools>:\n<tools>\n{tools_block}\n</tools>\n\n"
+        f"{_TOOL_CALL_INSTRUCTION}\n\n"
+        f"{user_query}"
+    )
+    return prompt
+
+
+def build_valid_completion(tool_name, args):
+    """Build the expected completion for a valid tool call."""
+    call_obj = {"name": tool_name, "arguments": args}
+    return (
+        "<tool_call>\n"
+        + json.dumps(call_obj, ensure_ascii=False)
+        + "\n</tool_call>"
+    )
+
+
+
+# Sample construction
+def build_tool_call_sample(
+    key, tool, all_tools, rng,
+    min_tools=1, max_tools=3,
+    is_valid=True, min_refusal_words=5,
+):
+    """Build one complete tool-call gym sample.
+
+    Args:
+        key: Integer sample identifier.
+        tool: The target tool (used for valid tasks; ignored for refusal).
+        all_tools: Full pool of available tools.
+        rng: `random.Random` instance.
+        min_tools: Minimum tools to include in prompt.
+        max_tools: Maximum tools to include in prompt.
+        is_valid: If True, build a valid tool-call task; else a refusal task.
+        min_refusal_words: Minimum words expected in a refusal response.
+
+    Returns:
+        Dict with keys: key, prompt, verifier_id_list, kwargs.
+    """
+    if is_valid:
+        # Select distractor tools
+        num_extra = rng.randint(max(0, min_tools - 1), max(0, max_tools - 1))
+        other_tools = [t for t in all_tools if t["function"]["name"] != tool["function"]["name"]]
+        extra = rng.sample(other_tools, min(num_extra, len(other_tools)))
+
+        args = generate_tool_arguments(tool, rng)
+        prompt, _prompt_tools = build_valid_prompt(tool, rng, extra)
+
+        # Required arg keys from tool schema
+        params = tool["function"].get("parameters", {})
+        required_keys = list(params.get("required", []))
+        arg_types = get_tool_arg_types(tool)
+        # Only check types for keys we actually generated
+        checked_types = {k: arg_types[k] for k in args if k in arg_types}
+
+        verifier_ids = [
+            "tool_call:format",
+            "tool_call:name",
+            "tool_call:args_keys",
+            "tool_call:args_types",
+        ]
+        kwargs_list = [
+            {"expect_call": True},
+            {"expected_name": tool["function"]["name"]},
+            {"required_arg_keys": required_keys},
+            {"expected_arg_types": checked_types},
+        ]
+
+    else:
+        # Refusal task
+        num_distractors = rng.randint(min_tools, max_tools)
+        distractors = rng.sample(all_tools, min(num_distractors, len(all_tools)))
+        prompt = build_refusal_prompt(distractors, rng)
+
+        verifier_ids = [
+            "tool_call:format",
+            "tool_call:refusal",
+        ]
+        kwargs_list = [
+            {"expect_call": False},
+            {"min_refusal_words": min_refusal_words},
+        ]
+
+    return {
+        "key": key,
+        "prompt": prompt,
+        "verifier_id_list": verifier_ids,
+        "kwargs": kwargs_list,
+    }
+
+
+
+# Validation
+def validate_tool_call_sample(sample):
+    """Return a list of validation issues (empty = valid)."""
+    issues = []
+
+    n_ids = len(sample.get("verifier_id_list", []))
+    n_kw = len(sample.get("kwargs", []))
+    if n_ids != n_kw:
+        issues.append(
+            f"verifier_id_list length ({n_ids}) != kwargs length ({n_kw})"
+        )
+
+    for iid in sample.get("verifier_id_list", []):
+        if iid not in TOOL_CALL_TASK_IDS:
+            issues.append(f"Unknown tool-call task ID: {iid}")
+
+    if not sample.get("prompt", "").strip():
+        issues.append("Empty prompt")
+
+    # Must contain only the canonical keys
+    allowed_keys = {"key", "prompt", "verifier_id_list", "kwargs"}
+    extra_keys = set(sample.keys()) - allowed_keys
+    if extra_keys:
+        issues.append(f"Unexpected keys in sample: {extra_keys}")
+
+    return issues
+
+
+def sample_fingerprint(sample):
+    """Hashable fingerprint for deduplication."""
+    return sample.get("prompt", "")
+
+
+
+# Main generation loop
+def main(args):
+    output_path = Path(args.output_file)
+
+    data_path = args.data_file or str(_DATA_DIR / "tools.json")
+
+    all_tools, examples = load_tool_call_data(data_path)
+
+    if not all_tools:
+        print("Error: no tools loaded.")
+        return
+
+    num_samples = args.num_samples
+    num_refusals = int(num_samples * args.refusal_ratio)
+    num_valid = num_samples - num_refusals
+
+    print(
+        f"Loaded {len(all_tools)} tools, {len(examples)} existing examples.\n"
+        f"Generating {num_samples} samples "
+        f"({num_valid} valid + {num_refusals} refusal, seed={args.seed})"
+    )
+
+    samples = []
+    seen = set()
+    key_counter = args.start_key
+    retries_used = 0
+    max_retries = 20
+
+    # Generate valid samples
+    for i in range(num_valid):
+        sample = None
+        for attempt in range(max_retries):
+            rng = random.Random(args.seed + i * max_retries + attempt)
+            tool = rng.choice(all_tools)
+
+            candidate = build_tool_call_sample(
+                key=key_counter,
+                tool=tool,
+                all_tools=all_tools,
+                rng=rng,
+                min_tools=args.min_tools,
+                max_tools=args.max_tools,
+                is_valid=True,
+                min_refusal_words=args.min_refusal_words,
+            )
+
+            fp = sample_fingerprint(candidate)
+            if fp not in seen:
+                sample = candidate
+                seen.add(fp)
+                break
+            retries_used += 1
+
+        if sample is None:
+            print(f"  Warning: could not produce unique valid sample #{i+1}")
+            continue
+        samples.append(sample)
+        key_counter += 1
+
+    # Generate refusal samples
+    for i in range(num_refusals):
+        sample = None
+        offset = num_valid * max_retries
+        for attempt in range(max_retries):
+            rng = random.Random(args.seed + offset + i * max_retries + attempt)
+
+            candidate = build_tool_call_sample(
+                key=key_counter,
+                tool=None,
+                all_tools=all_tools,
+                rng=rng,
+                min_tools=args.min_tools,
+                max_tools=args.max_tools,
+                is_valid=False,
+                min_refusal_words=args.min_refusal_words,
+            )
+
+            fp = sample_fingerprint(candidate)
+            if fp not in seen:
+                sample = candidate
+                seen.add(fp)
+                break
+            retries_used += 1
+
+        if sample is None:
+            print(f"  Warning: could not produce unique refusal sample #{i+1}")
+            continue
+        samples.append(sample)
+        key_counter += 1
+
+    # Shuffle to interleave valid and refusal
+    rng_shuffle = random.Random(args.seed)
+    rng_shuffle.shuffle(samples)
+
+    # Validate all samples
+    total_issues = 0
+    for s in samples:
+        issues = validate_tool_call_sample(s)
+        if issues:
+            total_issues += len(issues)
+            if args.verbose:
+                print(f"  Key {s['key']}: {issues}")
+
+    n_valid = sum(
+        1 for s in samples
+        if any(kw.get("expect_call") is True for kw in s["kwargs"])
+    )
+    n_refusal = len(samples) - n_valid
+    unique_fps = len({sample_fingerprint(s) for s in samples})
+
+    print(f"\nResults:")
+    print(f"  Generated samples:  {len(samples)}")
+    print(f"  Valid tool-calls:   {n_valid}")
+    print(f"  Refusals:           {n_refusal}")
+    print(
+        f"  Unique:             {unique_fps}/{len(samples)}"
+        f"  ({100 * unique_fps / max(len(samples), 1):.1f}%)"
+    )
+    print(f"  Validation issues:  {total_issues}")
+    if retries_used:
+        print(f"  Uniqueness retries: {retries_used}")
+
+    # Hard assertions
+    assert unique_fps == len(samples), (
+        f"FAIL: {len(samples) - unique_fps} duplicate samples"
+    )
+    assert total_issues == 0, (
+        f"FAIL: {total_issues} validation issues found"
+    )
+
+    # Write output
+    use_jsonl = output_path.suffix.lower() == ".jsonl"
+    with open(output_path, "w", encoding="utf-8") as f:
+        if use_jsonl:
+            for sample in samples:
+                f.write(json.dumps(sample, ensure_ascii=False) + "\n")
+        else:
+            json.dump(samples, f, ensure_ascii=False, indent=2)
+
+    fmt = "JSONL" if use_jsonl else "JSON"
+    print(f"\nOutput written to: {output_path} ({fmt})")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Procedural tool-calling task generator.",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        required=True,
+        help="Path to output JSON/JSONL file.",
+    )
+    parser.add_argument(
+        "--num_samples",
+        type=int,
+        default=500,
+        help="Total number of samples to generate (default: 500).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility (default: 42).",
+    )
+    parser.add_argument(
+        "--start_key",
+        type=int,
+        default=0,
+        help="Starting key value for generated samples (default: 0).",
+    )
+    parser.add_argument(
+        "--min_tools",
+        type=int,
+        default=1,
+        help="Minimum number of tools in prompt (default: 1).",
+    )
+    parser.add_argument(
+        "--max_tools",
+        type=int,
+        default=3,
+        help="Maximum number of tools in prompt (default: 3).",
+    )
+    parser.add_argument(
+        "--refusal_ratio",
+        type=float,
+        default=0.5,
+        help="Fraction of samples that are refusal tasks (default: 0.5).",
+    )
+    parser.add_argument(
+        "--min_refusal_words",
+        type=int,
+        default=5,
+        help="Minimum words expected in refusal responses (default: 5).",
+    )
+    parser.add_argument(
+        "--data_file",
+        type=str,
+        default=None,
+        help="Path to tools.json (default: data/tools.json).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print detailed validation warnings.",
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/gym/tasks_metadata.py
+++ b/gym/tasks_metadata.py
@@ -720,3 +720,39 @@ def generate_email_task_description(task_id):
             "Um campo específico deve ter o valor exato esperado.",
     }
     return descriptions.get(task_id, "")
+
+
+# Tool-call Tasks
+_TOOL_CALL = "tool_call:"
+
+TOOL_CALL_TASK_IDS = [
+    _TOOL_CALL + "format",
+    _TOOL_CALL + "name",
+    _TOOL_CALL + "args_keys",
+    _TOOL_CALL + "args_types",
+    _TOOL_CALL + "refusal",
+]
+
+TOOL_CALL_DEFAULTS = {
+    "min_tools": 1,
+    "max_tools": 3,
+    "refusal_ratio": 0.5,
+    "min_refusal_words": 5,
+}
+
+
+def generate_tool_call_task_description(task_id):
+    """Return a brief Portuguese description for a tool-call task ID."""
+    descriptions = {
+        _TOOL_CALL + "format":
+            "Verificar se a resposta contém uma chamada de ferramenta formatada corretamente.",
+        _TOOL_CALL + "name":
+            "Verificar se a ferramenta correta foi invocada.",
+        _TOOL_CALL + "args_keys":
+            "Verificar se os argumentos contêm as chaves obrigatórias.",
+        _TOOL_CALL + "args_types":
+            "Verificar se os tipos dos argumentos estão corretos.",
+        _TOOL_CALL + "refusal":
+            "Verificar se o modelo recusou corretamente sem chamar ferramentas.",
+    }
+    return descriptions.get(task_id, "")

--- a/gym/tests.py
+++ b/gym/tests.py
@@ -822,7 +822,6 @@ from generate_from_email_templates import (
 )
 from tasks_metadata import (
     EMAIL_TASK_IDS,
-    EMAIL_ALL_FIELDS,
     EMAIL_INJECTED_FIELDS,
 )
 
@@ -1090,6 +1089,225 @@ for tid in EMAIL_TASK_IDS:
     assert tid in VERIFICATION_REGISTRY, f"Missing registry entry for {tid}"
 
 print("Test 22 — email end-to-end (build + validate + verify): OK ✓")
+
+# %%
+#######################################
+# 23. Tool-call verifiers — pass and fail scenarios
+#######################################
+from tasks_metadata import TOOL_CALL_TASK_IDS
+
+# 23a. Valid tool call — all verifiers pass
+v_tc = Verifier(
+    verifier_id_list=[
+        "tool_call:format",
+        "tool_call:name",
+        "tool_call:args_keys",
+        "tool_call:args_types",
+    ],
+    kwargs=[
+        {"expect_call": True},
+        {"expected_name": "calculate_distance"},
+        {"required_arg_keys": ["source", "destination"]},
+        {"expected_arg_types": {"source": "string", "destination": "string"}},
+    ],
+    completion=(
+        '<tool_call>\n'
+        '{"name": "calculate_distance", "arguments": '
+        '{"source": "New York", "destination": "Los Angeles"}}\n'
+        '</tool_call>'
+    ),
+)
+assert v_tc.verify() == [True, True, True, True]
+
+# 23b. Wrong tool name
+v_tc2 = Verifier(
+    verifier_id_list=["tool_call:format", "tool_call:name"],
+    kwargs=[
+        {"expect_call": True},
+        {"expected_name": "calculate_distance"},
+    ],
+    completion='<tool_call>\n{"name": "wrong_tool", "arguments": {}}\n</tool_call>',
+)
+assert v_tc2.verify() == [True, False]
+
+# 23c. Missing required arg keys
+v_tc3 = Verifier(
+    verifier_id_list=["tool_call:args_keys"],
+    kwargs=[{"required_arg_keys": ["source", "destination"]}],
+    completion='<tool_call>\n{"name": "x", "arguments": {"source": "NYC"}}\n</tool_call>',
+)
+assert v_tc3.verify() == [False]
+
+# 23d. Wrong argument types
+v_tc4 = Verifier(
+    verifier_id_list=["tool_call:args_types"],
+    kwargs=[{"expected_arg_types": {"amount": "number", "currency": "string"}}],
+    completion='<tool_call>\n{"name": "x", "arguments": {"amount": "abc", "currency": "USD"}}\n</tool_call>',
+)
+assert v_tc4.verify() == [False]
+
+# 23e. Refusal — correct
+v_tc5 = Verifier(
+    verifier_id_list=["tool_call:format", "tool_call:refusal"],
+    kwargs=[{"expect_call": False}, {"min_refusal_words": 5}],
+    completion="Sinto muito, mas não posso fazer isso. Minhas funções são limitadas.",
+)
+assert v_tc5.verify() == [True, True]
+
+# 23f. Refusal fails — model called a tool when it shouldn't
+v_tc6 = Verifier(
+    verifier_id_list=["tool_call:format", "tool_call:refusal"],
+    kwargs=[{"expect_call": False}, {"min_refusal_words": 5}],
+    completion='<tool_call>\n{"name": "x", "arguments": {}}\n</tool_call>',
+)
+assert v_tc6.verify() == [False, False]
+
+# 23g. No tool_call tags when expected
+v_tc7 = Verifier(
+    verifier_id_list=["tool_call:format"],
+    kwargs=[{"expect_call": True}],
+    completion="Aqui está a resposta sem ferramenta.",
+)
+assert v_tc7.verify() == [False]
+
+# 23h. Malformed JSON in tool_call
+v_tc8 = Verifier(
+    verifier_id_list=["tool_call:format"],
+    kwargs=[{"expect_call": True}],
+    completion="<tool_call>\nnot json\n</tool_call>",
+)
+assert v_tc8.verify() == [False]
+
+# 23i. Refusal too short
+v_tc9 = Verifier(
+    verifier_id_list=["tool_call:refusal"],
+    kwargs=[{"min_refusal_words": 10}],
+    completion="Não posso.",
+)
+assert v_tc9.verify() == [False]
+
+print("Test 23 — tool-call verifiers (pass/fail/edge): OK ✓")
+
+# %%
+#######################################
+# 24. Tool-call end-to-end (generate + validate + verify)
+#######################################
+from generate_from_tool_call_templates import (
+    load_tool_call_data,
+    build_tool_call_sample,
+    build_valid_completion,
+    validate_tool_call_sample,
+    sample_fingerprint as tc_fingerprint,
+)
+from pathlib import Path
+
+_data_dir = Path(__file__).resolve().parent / "data"
+all_tools, _examples = load_tool_call_data(_data_dir / "tools.json")
+assert len(all_tools) > 0, "No tools loaded"
+
+rng = random.Random(42)
+
+# Verify output format matches the canonical gym schema
+for i in range(5):
+    tool = rng.choice(all_tools)
+    sample = build_tool_call_sample(
+        key=i, tool=tool, all_tools=all_tools,
+        rng=random.Random(42 + i), is_valid=True,
+    )
+    assert set(sample.keys()) == {"key", "prompt", "verifier_id_list", "kwargs"}, \
+        f"Valid sample has wrong keys: {set(sample.keys())}"
+
+for i in range(5):
+    sample = build_tool_call_sample(
+        key=50 + i, tool=None, all_tools=all_tools,
+        rng=random.Random(99 + i), is_valid=False,
+    )
+    assert set(sample.keys()) == {"key", "prompt", "verifier_id_list", "kwargs"}, \
+        f"Refusal sample has wrong keys: {set(sample.keys())}"
+
+# Generate valid samples and verify with a matching completion
+rng2 = random.Random(42)
+for i in range(10):
+    tool = rng2.choice(all_tools)
+    sample_rng = random.Random(42 + i)
+    sample = build_tool_call_sample(
+        key=i, tool=tool, all_tools=all_tools,
+        rng=sample_rng, is_valid=True,
+    )
+    issues = validate_tool_call_sample(sample)
+    assert not issues, f"Valid sample {i} has issues: {issues}"
+
+    # Build a completion that matches the expected tool call
+    expected_name = sample["kwargs"][1]["expected_name"]
+    expected_arg_keys = sample["kwargs"][2]["required_arg_keys"]
+    expected_arg_types = sample["kwargs"][3]["expected_arg_types"]
+    # Generate arguments that satisfy the verifiers (include all typed args)
+    args = {}
+    for key in expected_arg_types:
+        t = expected_arg_types[key]
+        if t == "string":
+            args[key] = "test_value"
+        elif t in ("number", "integer"):
+            args[key] = 42
+        elif t == "boolean":
+            args[key] = True
+        elif t == "array":
+            args[key] = ["a", "b"]
+        elif t == "object":
+            args[key] = {"k": "v"}
+        else:
+            args[key] = "test"
+    completion = build_valid_completion(expected_name, args)
+
+    v = Verifier(
+        verifier_id_list=sample["verifier_id_list"],
+        kwargs=sample["kwargs"],
+        completion=completion,
+    )
+    results = v.verify()
+    assert all(results), f"Valid sample {i} verification failed: {results}"
+
+# Generate and verify refusal samples
+for i in range(10):
+    sample = build_tool_call_sample(
+        key=100 + i, tool=None, all_tools=all_tools,
+        rng=random.Random(99 + i), is_valid=False,
+    )
+    issues = validate_tool_call_sample(sample)
+    assert not issues, f"Refusal sample {i} has issues: {issues}"
+
+    refusal_text = (
+        "Sinto muito, mas não tenho a capacidade de realizar essa tarefa. "
+        "Minhas funções são limitadas às que me foram fornecidas."
+    )
+    v = Verifier(
+        verifier_id_list=sample["verifier_id_list"],
+        kwargs=sample["kwargs"],
+        completion=refusal_text,
+    )
+    results = v.verify()
+    assert all(results), f"Refusal sample {i} verification failed: {results}"
+
+# Uniqueness check
+fps = set()
+rng3 = random.Random(42)
+for i in range(50):
+    tool = rng3.choice(all_tools)
+    sample = build_tool_call_sample(
+        key=200 + i,
+        tool=tool,
+        all_tools=all_tools,
+        rng=random.Random(200 + i),
+        is_valid=True,
+    )
+    fps.add(tc_fingerprint(sample))
+assert len(fps) == 50, f"Expected 50 unique fingerprints, got {len(fps)}"
+
+# All TOOL_CALL_TASK_IDS must be in VERIFICATION_REGISTRY
+for tid in TOOL_CALL_TASK_IDS:
+    assert tid in VERIFICATION_REGISTRY, f"Missing registry entry for {tid}"
+
+print("Test 24 — tool-call end-to-end (generate + validate + verify): OK ✓")
 
 # %%
 #######################################

--- a/gym/verifier.py
+++ b/gym/verifier.py
@@ -56,6 +56,11 @@ from verifiers import (
     ResponseLanguageChecker,
     SectionChecker,
     TitleChecker,
+    ToolCallArgsKeysChecker,
+    ToolCallArgsTypesChecker,
+    ToolCallFormatChecker,
+    ToolCallNameChecker,
+    ToolCallRefusalChecker,
     TwoResponsesChecker,
     WordAtPositionChecker,
 )
@@ -106,6 +111,12 @@ VERIFICATION_REGISTRY = {
     "email:json_format": EmailJsonFormatChecker,
     "email:schema_keys": EmailSchemaKeysChecker,
     "email:field_value": EmailFieldValueChecker,
+    # Tool-call tasks
+    "tool_call:format": ToolCallFormatChecker,
+    "tool_call:name": ToolCallNameChecker,
+    "tool_call:args_keys": ToolCallArgsKeysChecker,
+    "tool_call:args_types": ToolCallArgsTypesChecker,
+    "tool_call:refusal": ToolCallRefusalChecker,
 }
 
 

--- a/gym/verifiers.py
+++ b/gym/verifiers.py
@@ -1972,3 +1972,183 @@ class EmailFieldValueChecker(TaskVerifier):
                 )
             return False
         return str(actual).strip() == str(self._expected_value).strip()
+
+
+_TOOL_CALL_OPEN = "<tool_call>"
+_TOOL_CALL_CLOSE = "</tool_call>"
+
+
+def _extract_tool_call_json(text):
+    """Extract the JSON object from within <tool_call>...</tool_call> tags.
+
+    Returns the parsed dict, or None if extraction fails.
+    """
+    start = text.find(_TOOL_CALL_OPEN)
+    end = text.find(_TOOL_CALL_CLOSE)
+    if start == -1 or end == -1 or end <= start:
+        return None
+    inner = text[start + len(_TOOL_CALL_OPEN):end].strip()
+    try:
+        return json.loads(inner)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+class ToolCallFormatChecker(TaskVerifier):
+    """Check that the response contains a well-formed <tool_call> block.
+
+    For valid tasks (``expect_call=True``) the response must contain a
+    properly formatted ``<tool_call>...</tool_call>`` block with parseable
+    JSON inside.
+
+    For invalid/refusal tasks (``expect_call=False``) the response must
+    NOT contain any ``<tool_call>`` tag.
+    """
+
+    def build_description(self, *, expect_call=True):
+        self._expect_call = expect_call
+        if self._expect_call:
+            return (
+                "A resposta deve conter uma chamada de ferramenta "
+                "formatada dentro de tags <tool_call>...</tool_call>."
+            )
+        return (
+            "A resposta NÃO deve conter nenhuma chamada de ferramenta. "
+            "Explique educadamente por que nenhuma ferramenta se aplica."
+        )
+
+    def get_instruction_args(self):
+        return {"expect_call": self._expect_call}
+
+    def get_instruction_args_keys(self):
+        return ["expect_call"]
+
+    def check_following(self, value):
+        has_tag = _TOOL_CALL_OPEN in value
+        if self._expect_call:
+            return _extract_tool_call_json(value) is not None
+        return not has_tag
+
+
+class ToolCallNameChecker(TaskVerifier):
+    """Check that the tool_call uses the correct function name."""
+
+    def build_description(self, *, expected_name=None):
+        self._expected_name = expected_name or ""
+        return (
+            f"A chamada de ferramenta deve invocar a função \"{self._expected_name}\"."
+        )
+
+    def get_instruction_args(self):
+        return {"expected_name": self._expected_name}
+
+    def get_instruction_args_keys(self):
+        return ["expected_name"]
+
+    def check_following(self, value):
+        obj = _extract_tool_call_json(value)
+        if obj is None:
+            return False
+        return obj.get("name") == self._expected_name
+
+
+class ToolCallArgsKeysChecker(TaskVerifier):
+    """Check that the tool_call arguments contain exactly the required keys."""
+
+    def build_description(self, *, required_arg_keys=None):
+        self._required_keys = sorted(required_arg_keys or [])
+        keys_str = ", ".join(self._required_keys)
+        return (
+            f"Os argumentos da chamada devem conter as chaves: {keys_str}."
+        )
+
+    def get_instruction_args(self):
+        return {"required_arg_keys": self._required_keys}
+
+    def get_instruction_args_keys(self):
+        return ["required_arg_keys"]
+
+    def check_following(self, value):
+        obj = _extract_tool_call_json(value)
+        if obj is None:
+            return False
+        args = obj.get("arguments", {})
+        if not isinstance(args, dict):
+            return False
+        return set(self._required_keys).issubset(set(args.keys()))
+
+
+class ToolCallArgsTypesChecker(TaskVerifier):
+    """Check that the tool_call argument values match the expected JSON types.
+
+    ``expected_arg_types`` maps argument name → JSON type string
+    (``"string"``, ``"number"``, ``"integer"``, ``"boolean"``, ``"array"``,
+    ``"object"``).
+    """
+
+    _TYPE_MAP = {
+        "string": str,
+        "number": (int, float),
+        "integer": int,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+
+    def build_description(self, *, expected_arg_types=None):
+        self._expected_types = expected_arg_types or {}
+        parts = [f"{k}: {v}" for k, v in sorted(self._expected_types.items())]
+        return (
+            "Os tipos dos argumentos devem ser: "
+            + ", ".join(parts) + "."
+        )
+
+    def get_instruction_args(self):
+        return {"expected_arg_types": self._expected_types}
+
+    def get_instruction_args_keys(self):
+        return ["expected_arg_types"]
+
+    def check_following(self, value):
+        obj = _extract_tool_call_json(value)
+        if obj is None:
+            return False
+        args = obj.get("arguments", {})
+        if not isinstance(args, dict):
+            return False
+        for key, expected_type_str in self._expected_types.items():
+            if key not in args:
+                return False
+            py_type = self._TYPE_MAP.get(expected_type_str)
+            if py_type is None:
+                continue
+            if not isinstance(args[key], py_type):
+                # Allow int where number is expected
+                if expected_type_str == "number" and isinstance(args[key], (int, float)):
+                    continue
+                return False
+        return True
+
+
+class ToolCallRefusalChecker(TaskVerifier):
+    """Check that a refusal response does NOT contain tool_call tags
+    and provides a minimum-length explanation."""
+
+    def build_description(self, *, min_refusal_words=None):
+        self._min_words = min_refusal_words or 5
+        return (
+            "A resposta deve recusar educadamente sem usar nenhuma ferramenta "
+            f"e conter pelo menos {self._min_words} palavras de explicação."
+        )
+
+    def get_instruction_args(self):
+        return {"min_refusal_words": self._min_words}
+
+    def get_instruction_args_keys(self):
+        return ["min_refusal_words"]
+
+    def check_following(self, value):
+        if _TOOL_CALL_OPEN in value:
+            return False
+        word_count = len(value.split())
+        return word_count >= self._min_words


### PR DESCRIPTION
This pull request introduces support for "tool-call" tasks in the codebase, including new verifiers, task metadata, and tests. It also makes minor improvements and cleanups to existing email template handling. The main focus is on enabling automated validation of model outputs that involve tool invocation.

**Tool-call task support:**

* Added new verifier classes for tool-call tasks: `ToolCallFormatChecker`, `ToolCallNameChecker`, `ToolCallArgsKeysChecker`, `ToolCallArgsTypesChecker`, and `ToolCallRefusalChecker` in `gym/verifiers.py`, along with helper functions for extracting tool-call JSON from responses. These checkers validate the structure, content, and correctness of tool-call outputs and refusals.
* Registered the new tool-call verifiers in the `VERIFICATION_REGISTRY` in `gym/verifier.py`, enabling their use in automated tests and sample generation.
* Added tool-call task IDs, default parameters, and Portuguese descriptions to `gym/tasks_metadata.py`, supporting generation and documentation of tool-call tasks.
