### PR TITLE
updated kwarg parsing/storing and changed the key field to an ID field

### DIFF
--- a/gym/generate_from_email_templates.py
+++ b/gym/generate_from_email_templates.py
@@ -21,18 +21,19 @@ Usage:
     python generate_from_email_templates.py \
         --emails_file ./data/emails.jsonl \
         --output_file email_tasks.jsonl \
-        --num_samples 500
+        --num_samples 10000
 
     python generate_from_email_templates.py \
         --emails_file ./data/emails.jsonl \
-        --output_file email_tasks.json \
-        --num_samples 1000 \
+        --output_file email_tasks.jsonl \
+        --num_samples 10000 \
         --min_fields 3 --max_fields 7 \
-        --seed 42 --start_key 0 --verbose
+        --seed 42 --verbose
 """
 
 import json
 import random
+import hashlib
 import argparse
 from pathlib import Path
 
@@ -180,18 +181,17 @@ def build_email_context(email_text, injected_values):
 
 
 # Sample construction
-def build_email_sample(email_text, key, fields, injected_values, rng):
+def build_email_sample(email_text, fields, injected_values, rng):
     """Build one email extraction gym sample.
 
     Args:
         email_text: Raw email content (will have metadata header prepended).
-        key: Integer identifier for this sample.
         fields: List of field names to request in the output JSON.
         injected_values: Dict of all five injected field values.
         rng: `random.Random` instance for reproducibility.
 
     Returns:
-        Dict with keys: key, prompt, verifier_id_list, kwargs.
+        Dict with keys: id, prompt, verifier_id_list, kwargs.
     """
     email_with_meta = build_email_context(email_text, injected_values)
 
@@ -226,11 +226,12 @@ def build_email_sample(email_text, key, fields, injected_values, rng):
                 "expected_value": injected_values[field],
             })
 
+    sample_id = hashlib.md5(prompt.encode()).hexdigest()
     return {
-        "key": key,
+        "id": sample_id,
         "prompt": prompt,
         "verifier_id_list": verifier_id_list,
-        "kwargs": kwargs_list,
+        "kwargs": [json.dumps(kw, ensure_ascii=False) for kw in kwargs_list],
     }
 
 
@@ -261,6 +262,8 @@ def validate_email_sample(sample):
 
     for i, iid in enumerate(vids):
         kw = sample["kwargs"][i] if i < len(sample.get("kwargs", [])) else {}
+        if isinstance(kw, str):
+            kw = json.loads(kw)
         if iid == "email:schema_keys":
             keys = kw.get("required_keys", [])
             if not keys:
@@ -340,7 +343,6 @@ def main(args):
 
     samples = []
     seen = set()
-    key_counter = args.start_key
     retries_used = 0
     max_retries = 20
 
@@ -358,16 +360,15 @@ def main(args):
 
             candidate = build_email_sample(
                 email_text=email_text,
-                key=key_counter,
                 fields=fields,
                 injected_values=injected,
                 rng=rng,
             )
 
-            fp = sample_fingerprint(candidate)
-            if fp not in seen:
+            sid = candidate["id"]
+            if sid not in seen:
                 sample = candidate
-                seen.add(fp)
+                seen.add(sid)
                 break
 
             retries_used += 1
@@ -377,7 +378,6 @@ def main(args):
             continue
 
         samples.append(sample)
-        key_counter += 1
 
     # Validate all samples
     total_issues = 0
@@ -386,23 +386,23 @@ def main(args):
         if issues:
             total_issues += len(issues)
             if args.verbose:
-                print(f"  Key {s['key']}: {issues}")
+                print(f"  ID {s['id']}: {issues}")
 
-    unique_fps = len({sample_fingerprint(s) for s in samples})
+    unique_ids = len({s['id'] for s in samples})
 
     print(f"\nResults:")
     print(f"  Generated samples:  {len(samples)}")
     print(
-        f"  Unique:             {unique_fps}/{len(samples)}"
-        f"  ({100 * unique_fps / max(len(samples), 1):.1f}%)"
+        f"  Unique:             {unique_ids}/{len(samples)}"
+        f"  ({100 * unique_ids / max(len(samples), 1):.1f}%)"
     )
     print(f"  Validation issues:  {total_issues}")
     if retries_used:
         print(f"  Retries used:       {retries_used}")
 
     assert total_issues == 0, f"FAIL: {total_issues} validation issues found"
-    assert unique_fps == len(samples), (
-        f"FAIL: {len(samples) - unique_fps} duplicate samples"
+    assert unique_ids == len(samples), (
+        f"FAIL: {len(samples) - unique_ids} duplicate samples"
     )
 
     use_jsonl = output_path.suffix.lower() == ".jsonl"
@@ -458,12 +458,6 @@ if __name__ == "__main__":
         type=int,
         default=42,
         help="Random seed for reproducibility (default: 42).",
-    )
-    parser.add_argument(
-        "--start_key",
-        type=int,
-        default=0,
-        help="Starting integer key for generated samples (default: 0).",
     )
     parser.add_argument(
         "--verbose",

--- a/gym/generate_from_instruction_templates.py
+++ b/gym/generate_from_instruction_templates.py
@@ -9,18 +9,19 @@ This generator constructs each sample from scratch:
 
 Usage:
     python generate_from_instruction_templates.py \
-        --output_file output.json \
-        --num_samples 10
+        --output_file instruct_tasks.jsonl \
+        --num_samples 50000
 
     python generate_from_instruction_templates.py \
-        --output_file output.json \
-        --num_samples 10 \
+        --output_file instruct_tasks.jsonl \
+        --num_samples 50000 \
         --min_modifiers 1 --max_modifiers 4 \
-        --seed 123 --verbose --start_key 0
+        --seed 123 --verbose
 """
 
 import json
 import random
+import hashlib
 import argparse
 from pathlib import Path
 
@@ -90,7 +91,7 @@ def _normalize_kwargs(kw):
         for k, v in kw.items()
     }
 
-def build_sample(template, key, min_modifiers=1, max_modifiers=4):
+def build_sample(template, min_modifiers=1, max_modifiers=4):
     """Build one complete sample from a template + random modifiers.
 
     The prompt is constructed by concatenating:
@@ -134,11 +135,12 @@ def build_sample(template, key, min_modifiers=1, max_modifiers=4):
     else:
         final_prompt = " ".join(prompt_parts)
 
+    sample_id = hashlib.md5(final_prompt.encode()).hexdigest()
     return {
-        "key": key,
+        "id": sample_id,
         "prompt": final_prompt,
         "verifier_id_list": verifier_ids,
-        "kwargs": kwargs_list,
+        "kwargs": [json.dumps(kw, ensure_ascii=False) for kw in kwargs_list],
     }
 
 
@@ -171,6 +173,8 @@ def validate_sample(sample):
     # Verify each modifier description appears in the prompt
     for i, iid in enumerate(sample.get("verifier_id_list", [])):
         kw = sample["kwargs"][i]
+        if isinstance(kw, str):
+            kw = json.loads(kw)
         desc = generate_description_for_verifier(iid, kw)
         if desc and desc not in sample.get("prompt", ""):
             issues.append(f"Description for {iid} not found in prompt")
@@ -190,7 +194,6 @@ def main(args):
 
     samples = []
     seen = set()
-    key_counter = args.start_key
     retries_used = 0
 
     for i in range(num_samples):
@@ -203,15 +206,14 @@ def main(args):
             template = random.choice(TEMPLATES)
             candidate = build_sample(
                 template,
-                key=key_counter,
                 min_modifiers=args.min_modifiers,
                 max_modifiers=args.max_modifiers,
             )
 
-            fp = sample_fingerprint(candidate)
-            if fp not in seen:
+            sid = candidate["id"]
+            if sid not in seen:
                 sample = candidate
-                seen.add(fp)
+                seen.add(sid)
                 break
 
             retries_used += 1
@@ -222,7 +224,6 @@ def main(args):
             continue
 
         samples.append(sample)
-        key_counter += 1
 
     # Validate
     total_issues = 0
@@ -231,12 +232,12 @@ def main(args):
         if issues:
             total_issues += len(issues)
             if args.verbose:
-                print(f"  Key {s['key']}: {issues}")
+                print(f"  ID {s['id']}: {issues}")
 
     conflict_free = sum(
         1 for s in samples if is_combination_valid(s["verifier_id_list"])
     )
-    unique_fps = len({sample_fingerprint(s) for s in samples})
+    unique_ids = len({s['id'] for s in samples})
 
     print(f"\nResults:")
     print(f"  Generated samples:  {len(samples)}")
@@ -245,8 +246,8 @@ def main(args):
         f"  ({100 * conflict_free / max(len(samples), 1):.1f}%)"
     )
     print(
-        f"  Unique:             {unique_fps}/{len(samples)}"
-        f"  ({100 * unique_fps / max(len(samples), 1):.1f}%)"
+        f"  Unique:             {unique_ids}/{len(samples)}"
+        f"  ({100 * unique_ids / max(len(samples), 1):.1f}%)"
     )
     print(f"  Validation issues:  {total_issues}")
     if retries_used:
@@ -256,8 +257,8 @@ def main(args):
     assert conflict_free == len(samples), (
         f"FAIL: {len(samples) - conflict_free} samples have instruction conflicts"
     )
-    assert unique_fps == len(samples), (
-        f"FAIL: {len(samples) - unique_fps} duplicate samples"
+    assert unique_ids == len(samples), (
+        f"FAIL: {len(samples) - unique_ids} duplicate samples"
     )
     assert total_issues == 0, (
         f"FAIL: {total_issues} validation issues found"
@@ -297,12 +298,6 @@ if __name__ == "__main__":
         type=int,
         default=42,
         help="Random seed for reproducibility (default: 42).",
-    )
-    parser.add_argument(
-        "--start_key",
-        type=int,
-        default=0,
-        help="Starting key value for generated samples (default: 0).",
     )
     parser.add_argument(
         "--min_modifiers",

--- a/gym/generate_from_long_context_templates.py
+++ b/gym/generate_from_long_context_templates.py
@@ -21,49 +21,49 @@ Sizing parameters:
   Haystack tasks use --max_seq_length + --tokenizer (target context in tokens).
 
 Usage examples:
-    # Word-list tasks only (5 types x 100 = 500 samples)
+    # Word-list tasks only (5 types x 2000 = 10000 samples)
     python generate_from_long_context_templates.py \
-        --output_file word_list.json \
-        --num_samples 100 \
+        --output_file word_list.jsonl \
+        --num_samples 2000 \
         --num_context_words 50 \
         --task_types common_words rare_words count_word \
                      word_at_position frequency_comparison
 
-    # Word-list tasks at multiple context sizes (5 types x 3 sizes x 100 = 1500 samples)
+    # Word-list tasks at multiple context sizes (5 types x 3 sizes x 2000 = 30000 samples)
     python generate_from_long_context_templates.py \
-        --output_file word_list.json \
-        --num_samples 100 \
+        --output_file word_list.jsonl \
+        --num_samples 2000 \
         --num_context_words 50 100 200 \
         --task_types common_words rare_words count_word \
                      word_at_position frequency_comparison
 
-    # Haystack tasks only (4 types x 1 seq_len x 100 = 400 samples)
+    # Haystack tasks only (4 types x 1 seq_len x 2000 = 8000 samples)
     python generate_from_long_context_templates.py \
-        --output_file haystack.json \
-        --num_samples 100 \
+        --output_file haystack.jsonl \
+        --num_samples 2000 \
         --max_seq_length 4096 \
-        --tokenizer gpt2 \
+        --tokenizer Polygl0t/Tucano2-0.6B-Base \
         --docs_dir data \
         --task_types needle_single_number needle_multi_number_same_key \
                      needle_multi_number_diff_keys needle_uuid
 
-    # Haystack tasks at multiple sequence lengths (4 types x 3 lengths x 100 = 1200 samples)
+    # Haystack tasks at multiple sequence lengths (4 types x 3 lengths x 2000 = 24000 samples)
     python generate_from_long_context_templates.py \
-        --output_file haystack.json \
-        --num_samples 100 \
+        --output_file haystack.jsonl \
+        --num_samples 2000 \
         --max_seq_length 2048 4096 8192 \
-        --tokenizer gpt2 \
+        --tokenizer Polygl0t/Tucano2-0.6B-Base \
         --docs_dir data \
         --task_types needle_single_number needle_multi_number_same_key \
                      needle_multi_number_diff_keys needle_uuid
 
     # All tasks (word-list sized by words, haystack sized by tokens)
     python generate_from_long_context_templates.py \
-        --output_file all_tasks.json \
-        --num_samples 100 \
-        --num_context_words 50 100 200 \
-        --max_seq_length 4096 \
-        --tokenizer gpt2 \
+        --output_file long_tasks.jsonl \
+        --num_samples 1000 \
+        --num_context_words 50 100 200 400 \
+        --max_seq_length 1024 2048 4096 8192 \
+        --tokenizer Polygl0t/Tucano2-0.6B-Base \
         --docs_dir data
 """
 
@@ -72,6 +72,7 @@ import uuid
 import random
 import re
 import sys
+import hashlib
 import argparse
 from collections import Counter
 from pathlib import Path
@@ -385,7 +386,7 @@ def calibrate_num_chars(tokenizer, max_seq_length, task_type, documents, rng, st
         local_rng = random.Random(rng.randint(0, 2**31))
         try:
             sample = build_sample(
-                template, key=0, documents=documents,
+                template, documents=documents,
                 num_chars=num_chars, rng=local_rng,
             )
         except Exception:
@@ -402,14 +403,14 @@ def calibrate_num_chars(tokenizer, max_seq_length, task_type, documents, rng, st
 
 
 #  Unified sample construction
-def build_sample(template, key, *, num_words=None,
+def build_sample(template, *, num_words=None,
                  documents=None, num_chars=None, rng=None):
     """Build one complete retrieval sample in the standardized format.
 
     For word-list tasks, provide *num_words* (target total list length).
     For haystack tasks, provide *documents*, *num_chars*, and *rng*.
 
-    Returns a dict with keys: key, prompt, verifier_id_list, kwargs.
+    Returns a dict with keys: id, prompt, verifier_id_list, kwargs.
     """
     task_type = template["task_type"]
     verifier_id = TASK_TYPE_TO_VERIFIER[task_type]
@@ -426,11 +427,12 @@ def build_sample(template, key, *, num_words=None,
     else:
         raise ValueError(f"Unknown task type: {task_type}")
 
+    sample_id = hashlib.md5(prompt.encode()).hexdigest()
     return {
-        "key": key,
+        "id": sample_id,
         "prompt": prompt,
         "verifier_id_list": [verifier_id],
-        "kwargs": [verifier_kwargs],
+        "kwargs": [json.dumps(verifier_kwargs, ensure_ascii=False)],
     }
 
 
@@ -659,7 +661,7 @@ def main(args):
     # Generate samples
     samples = []
     seen = set()
-    key_counter = args.start_key
+    sample_counter = 0
     retries_used = 0
     type_dist = Counter()
     size_dist = Counter()
@@ -671,28 +673,26 @@ def main(args):
             sample = None
 
             for attempt in range(max_retries):
-                random.seed(seed + key_counter * max_retries + attempt)
+                random.seed(seed + sample_counter * max_retries + attempt)
 
                 if tt in WORD_LIST_TASK_TYPES:
                     candidate = build_sample(
                         template,
-                        key=key_counter,
                         num_words=build_kwargs["num_words"],
                     )
                 else:
                     sample_rng = random.Random(rng.randint(0, 2**63))
                     candidate = build_sample(
                         template,
-                        key=key_counter,
                         documents=documents,
                         num_chars=build_kwargs["num_chars"],
                         rng=sample_rng,
                     )
 
-                fp = (candidate["prompt"], tt)
-                if fp not in seen:
+                sid = candidate["id"]
+                if sid not in seen:
                     sample = candidate
-                    seen.add(fp)
+                    seen.add(sid)
                     break
 
                 retries_used += 1
@@ -704,7 +704,7 @@ def main(args):
             samples.append(sample)
             type_dist[tt] += 1
             size_dist[ctx_size] += 1
-            key_counter += 1
+            sample_counter += 1
 
     # Validate
     total_issues = 0
@@ -713,9 +713,9 @@ def main(args):
         if issues:
             total_issues += len(issues)
             if args.verbose:
-                print(f"  Key {s['key']}: {issues}")
+                print(f"  ID {s['id']}: {issues}")
 
-    unique_count = len({s["prompt"] for s in samples})
+    unique_count = len({s["id"] for s in samples})
 
     print(f"\nResults:")
     print(f"  Generated samples:  {len(samples)}")
@@ -806,12 +806,6 @@ if __name__ == "__main__":
         type=int,
         default=42,
         help="Random seed for reproducibility (default: 42).",
-    )
-    parser.add_argument(
-        "--start_key",
-        type=int,
-        default=0,
-        help="Starting key index for samples (default: 0).",
     )
     parser.add_argument(
         "--verbose",

--- a/gym/generate_from_math_dataset.py
+++ b/gym/generate_from_math_dataset.py
@@ -12,29 +12,30 @@ Sources:
 
 Usage:
     python generate_from_math_dataset.py \
-        --output_file math_tasks.json \
-        --num_samples 500
+        --output_file math_tasks.jsonl \
+        --num_samples 20000
 
     python generate_from_math_dataset.py \
-        --output_file math_tasks.json \
-        --num_samples 500 \
+        --output_file math_tasks.jsonl \
+        --num_samples 20000 \
         --sources gsm8k math_sft \
-        --seed 42 --start_key 0 \
+        --seed 42 \
         --cache_dir ./.cache
 
     # Only GSM8K:
     python generate_from_math_dataset.py \
-        --output_file gsm8k_tasks.json \
+        --output_file gsm8k_tasks.jsonl \
         --sources gsm8k
 
     # Only gigaverbo math SFT:
     python generate_from_math_dataset.py \
-        --output_file math_sft_tasks.json \
+        --output_file math_sft_tasks.jsonl \
         --sources math_sft
 """
 
 import json
 import random
+import hashlib
 import argparse
 from pathlib import Path
 import datasets
@@ -95,13 +96,14 @@ def _is_valid_number(s):
 
 # Sample construction
 
-def build_sample(question, answer, key):
+def build_sample(question, answer):
     """Build one gym sample from a math (question, answer) pair."""
+    sample_id = hashlib.md5(question.encode()).hexdigest()
     return {
-        "key": key,
+        "id": sample_id,
         "prompt": question,
         "verifier_id_list": [VERIFIER_ID],
-        "kwargs": [{"expected_answer": answer}],
+        "kwargs": [json.dumps({"expected_answer": answer}, ensure_ascii=False)],
     }
 
 
@@ -114,7 +116,10 @@ def validate_sample(sample):
         issues.append("Empty verifier_id_list")
     if len(sample.get("verifier_id_list", [])) != len(sample.get("kwargs", [])):
         issues.append("verifier_id_list and kwargs length mismatch")
-    answer = sample.get("kwargs", [{}])[0].get("expected_answer", "")
+    first_kw = sample.get("kwargs", ["{}"])[0]
+    if isinstance(first_kw, str):
+        first_kw = json.loads(first_kw)
+    answer = first_kw.get("expected_answer", "")
     if not answer:
         issues.append("Missing expected_answer")
     return issues
@@ -156,19 +161,22 @@ def main(args):
     selected = all_pairs[:args.num_samples]
 
     samples = []
-    key_counter = args.start_key
+    seen = set()
     total_issues = 0
 
     for question, answer in selected:
-        sample = build_sample(question, answer, key_counter)
+        sample = build_sample(question, answer)
+        sid = sample["id"]
+        if sid in seen:
+            continue
+        seen.add(sid)
         issues = validate_sample(sample)
         if issues:
             total_issues += len(issues)
             if args.verbose:
-                print(f"  Key {key_counter}: {issues}")
+                print(f"  ID {sid}: {issues}")
             continue
         samples.append(sample)
-        key_counter += 1
 
     print(f"\nResults:")
     print(f"  Generated samples:  {len(samples)}")
@@ -210,12 +218,6 @@ if __name__ == "__main__":
         type=int,
         default=42,
         help="Random seed for reproducibility (default: 42).",
-    )
-    parser.add_argument(
-        "--start_key",
-        type=int,
-        default=0,
-        help="Starting key value for generated samples (default: 0).",
     )
     parser.add_argument(
         "--sources",

--- a/gym/generate_from_tool_call_templates.py
+++ b/gym/generate_from_tool_call_templates.py
@@ -13,15 +13,16 @@ Usage:
         --num_samples 500
 
     python generate_from_tool_call_templates.py \
-        --output_file tool_call_tasks.json \
-        --num_samples 1000 \
+        --output_file tool_call_tasks.jsonl \
+        --num_samples 20000 \
         --min_tools 1 --max_tools 3 \
-        --refusal_ratio 0.5 \
-        --seed 42 --start_key 0 --verbose
+        --refusal_ratio 0.2 \
+        --seed 42 --verbose
 """
 
 import json
 import random
+import hashlib
 import argparse
 from pathlib import Path
 
@@ -427,14 +428,13 @@ def build_valid_completion(tool_name, args):
 
 # Sample construction
 def build_tool_call_sample(
-    key, tool, all_tools, rng,
+    tool, all_tools, rng,
     min_tools=1, max_tools=3,
     is_valid=True, min_refusal_words=5,
 ):
     """Build one complete tool-call gym sample.
 
     Args:
-        key: Integer sample identifier.
         tool: The target tool (used for valid tasks; ignored for refusal).
         all_tools: Full pool of available tools.
         rng: `random.Random` instance.
@@ -444,7 +444,7 @@ def build_tool_call_sample(
         min_refusal_words: Minimum words expected in a refusal response.
 
     Returns:
-        Dict with keys: key, prompt, verifier_id_list, kwargs.
+        Dict with keys: id, prompt, verifier_id_list, kwargs.
     """
     if is_valid:
         # Select distractor tools
@@ -490,11 +490,12 @@ def build_tool_call_sample(
             {"min_refusal_words": min_refusal_words},
         ]
 
+    sample_id = hashlib.md5(prompt.encode()).hexdigest()
     return {
-        "key": key,
+        "id": sample_id,
         "prompt": prompt,
         "verifier_id_list": verifier_ids,
-        "kwargs": kwargs_list,
+        "kwargs": [json.dumps(kw, ensure_ascii=False) for kw in kwargs_list],
     }
 
 
@@ -519,7 +520,7 @@ def validate_tool_call_sample(sample):
         issues.append("Empty prompt")
 
     # Must contain only the canonical keys
-    allowed_keys = {"key", "prompt", "verifier_id_list", "kwargs"}
+    allowed_keys = {"id", "prompt", "verifier_id_list", "kwargs"}
     extra_keys = set(sample.keys()) - allowed_keys
     if extra_keys:
         issues.append(f"Unexpected keys in sample: {extra_keys}")
@@ -557,7 +558,6 @@ def main(args):
 
     samples = []
     seen = set()
-    key_counter = args.start_key
     retries_used = 0
     max_retries = 20
 
@@ -569,7 +569,6 @@ def main(args):
             tool = rng.choice(all_tools)
 
             candidate = build_tool_call_sample(
-                key=key_counter,
                 tool=tool,
                 all_tools=all_tools,
                 rng=rng,
@@ -579,10 +578,10 @@ def main(args):
                 min_refusal_words=args.min_refusal_words,
             )
 
-            fp = sample_fingerprint(candidate)
-            if fp not in seen:
+            sid = candidate["id"]
+            if sid not in seen:
                 sample = candidate
-                seen.add(fp)
+                seen.add(sid)
                 break
             retries_used += 1
 
@@ -590,7 +589,6 @@ def main(args):
             print(f"  Warning: could not produce unique valid sample #{i+1}")
             continue
         samples.append(sample)
-        key_counter += 1
 
     # Generate refusal samples
     for i in range(num_refusals):
@@ -600,7 +598,6 @@ def main(args):
             rng = random.Random(args.seed + offset + i * max_retries + attempt)
 
             candidate = build_tool_call_sample(
-                key=key_counter,
                 tool=None,
                 all_tools=all_tools,
                 rng=rng,
@@ -610,10 +607,10 @@ def main(args):
                 min_refusal_words=args.min_refusal_words,
             )
 
-            fp = sample_fingerprint(candidate)
-            if fp not in seen:
+            sid = candidate["id"]
+            if sid not in seen:
                 sample = candidate
-                seen.add(fp)
+                seen.add(sid)
                 break
             retries_used += 1
 
@@ -621,7 +618,6 @@ def main(args):
             print(f"  Warning: could not produce unique refusal sample #{i+1}")
             continue
         samples.append(sample)
-        key_counter += 1
 
     # Shuffle to interleave valid and refusal
     rng_shuffle = random.Random(args.seed)
@@ -634,30 +630,33 @@ def main(args):
         if issues:
             total_issues += len(issues)
             if args.verbose:
-                print(f"  Key {s['key']}: {issues}")
+                print(f"  ID {s['id']}: {issues}")
 
     n_valid = sum(
         1 for s in samples
-        if any(kw.get("expect_call") is True for kw in s["kwargs"])
+        if any(
+            json.loads(kw).get("expect_call") is True
+            for kw in s["kwargs"]
+        )
     )
     n_refusal = len(samples) - n_valid
-    unique_fps = len({sample_fingerprint(s) for s in samples})
+    unique_ids = len({s['id'] for s in samples})
 
     print(f"\nResults:")
     print(f"  Generated samples:  {len(samples)}")
     print(f"  Valid tool-calls:   {n_valid}")
     print(f"  Refusals:           {n_refusal}")
     print(
-        f"  Unique:             {unique_fps}/{len(samples)}"
-        f"  ({100 * unique_fps / max(len(samples), 1):.1f}%)"
+        f"  Unique:             {unique_ids}/{len(samples)}"
+        f"  ({100 * unique_ids / max(len(samples), 1):.1f}%)"
     )
     print(f"  Validation issues:  {total_issues}")
     if retries_used:
         print(f"  Uniqueness retries: {retries_used}")
 
     # Hard assertions
-    assert unique_fps == len(samples), (
-        f"FAIL: {len(samples) - unique_fps} duplicate samples"
+    assert unique_ids == len(samples), (
+        f"FAIL: {len(samples) - unique_ids} duplicate samples"
     )
     assert total_issues == 0, (
         f"FAIL: {total_issues} validation issues found"
@@ -697,12 +696,6 @@ if __name__ == "__main__":
         type=int,
         default=42,
         help="Random seed for reproducibility (default: 42).",
-    )
-    parser.add_argument(
-        "--start_key",
-        type=int,
-        default=0,
-        help="Starting key value for generated samples (default: 0).",
     )
     parser.add_argument(
         "--min_tools",

--- a/gym/tests.py
+++ b/gym/tests.py
@@ -2,8 +2,13 @@
 #######################################
 # 1. Imports & Setup
 #######################################
+import json
 import random
 import string as _string
+
+def _parse_kw(kw):
+    """Deserialize a kwargs entry (string or dict) into a dict."""
+    return json.loads(kw) if isinstance(kw, str) else kw
 
 from tasks_metadata import (
     ALL_VERIFIER_IDS,
@@ -28,7 +33,7 @@ from generate_from_instruction_templates import (
     MODIFIER_IDS,
 )
 
-print("All imports OK ✓")
+print("All imports OK ✅")
 
 # %%
 #######################################
@@ -75,7 +80,7 @@ v2 = Verifier(
 )
 r2 = v2.verify()
 assert r2 == [False, False, True], f"Expected [False, False, True], got {r2}"
-print("Test 2 — multi-constraint pass + partial failure: OK ✓")
+print("Test 2 — multi-constraint pass + partial failure: OK ✅")
 
 # %%
 #######################################
@@ -111,7 +116,7 @@ v2 = Verifier(
     completion="Entretanto nada de especial aqui.",
 )
 assert v2.verify() == [False, False, False]
-print("Test 3 — keywords + forbidden + frequency: OK ✓")
+print("Test 3 — keywords + forbidden + frequency: OK ✅")
 
 # %%
 #######################################
@@ -162,7 +167,7 @@ v2 = Verifier(
     completion="Curto.",
 )
 assert v2.verify() == [False, False, False, False, False]
-print("Test 4 — length constraints + detectable content: OK ✓")
+print("Test 4 — length constraints + detectable content: OK ✅")
 
 # %%
 #######################################
@@ -232,7 +237,7 @@ v9 = Verifier(
     completion="Isso não é JSON.",
 )
 assert v9.verify() == [False]
-print("Test 5 — detectable format verifiers: OK ✓")
+print("Test 5 — detectable format verifiers: OK ✅")
 
 # %%
 #######################################
@@ -281,7 +286,7 @@ v6 = Verifier(
     completion="Esta resposta não está entre aspas.",
 )
 assert v6.verify() == [False]
-print("Test 6 — combination + startend verifiers: OK ✓")
+print("Test 6 — combination + startend verifiers: OK ✅")
 
 # %%
 #######################################
@@ -297,7 +302,7 @@ try:
     assert False, "Should have raised ValueError"
 except ValueError as e:
     assert "Unknown verifier ID" in str(e)
-print("Test 7 — unknown verifier raises error: OK ✓")
+print("Test 7 — unknown verifier raises error: OK ✅")
 
 # %%
 #######################################
@@ -325,7 +330,7 @@ for tid in LONG_CONTEXT_TASK_IDS:
     assert tid in VERIFICATION_REGISTRY, f"Missing registry entry: {tid}"
 for tid in HAYSTACK_TASK_IDS:
     assert tid in VERIFICATION_REGISTRY, f"Missing registry entry: {tid}"
-print("Test 8 — metadata integrity (registry + conflicts): OK ✓")
+print("Test 8 — metadata integrity (registry + conflicts): OK ✅")
 
 # %%
 #######################################
@@ -349,7 +354,7 @@ assert all(val is None for val in kw.values()), "All empty kwargs should be None
 kw["language"] = "pt"
 kw2 = make_empty_kwargs()
 assert kw2["language"] is None, "make_empty_kwargs should return independent copies"
-print("Test 9 — metadata helpers: OK ✓")
+print("Test 9 — metadata helpers: OK ✅")
 
 # %%
 #######################################
@@ -389,7 +394,7 @@ for t in TEMPLATES:
     filled = fill_template(t)
     assert isinstance(filled, str) and len(filled) > 0
     assert "{" not in filled, f"Unfilled slot in template {t['id']}: {filled}"
-print(f"Test 10 — generation pipeline ({len(TEMPLATES)} templates, {len(ALL_VERIFIER_IDS)} verifiers): OK ✓")
+print(f"Test 10 — generation pipeline ({len(TEMPLATES)} templates, {len(ALL_VERIFIER_IDS)} verifiers): OK ✅")
 
 # %%
 #######################################
@@ -405,25 +410,25 @@ for iid in ids:
 
 # build_sample
 template = TEMPLATES[0]
-sample = build_sample(template, key=99, min_modifiers=1, max_modifiers=3)
-assert "key" in sample and sample["key"] == 99
+sample = build_sample(template, min_modifiers=1, max_modifiers=3)
+assert "id" in sample and isinstance(sample["id"], str) and len(sample["id"]) == 32
 assert "prompt" in sample and len(sample["prompt"]) > 0
 assert len(sample["verifier_id_list"]) == len(sample["kwargs"])
 assert is_combination_valid(sample["verifier_id_list"])
 
 # validate_sample — valid
-sample2 = build_sample(TEMPLATES[0], key=1, min_modifiers=1, max_modifiers=2)
+sample2 = build_sample(TEMPLATES[0], min_modifiers=1, max_modifiers=2)
 assert validate_sample(sample2) == [], f"Expected no issues, got {validate_sample(sample2)}"
 
 # validate_sample — bad (unknown verifier + empty prompt)
 bad_sample = {
-    "key": 0, "prompt": "Test",
+    "id": "dummy", "prompt": "Test",
     "verifier_id_list": ["fake_category:nonexistent"], "kwargs": [{}],
 }
 issues = validate_sample(bad_sample)
 assert len(issues) > 0 and any("Unknown" in i for i in issues)
 bad_sample2 = {
-    "key": 0, "prompt": "   ",
+    "id": "dummy", "prompt": "   ",
     "verifier_id_list": [], "kwargs": [],
 }
 assert any("Empty prompt" in i for i in validate_sample(bad_sample2))
@@ -432,10 +437,10 @@ assert any("Empty prompt" in i for i in validate_sample(bad_sample2))
 fps = set()
 for i in range(20):
     random.seed(i)
-    s = build_sample(random.choice(TEMPLATES), key=i, min_modifiers=1, max_modifiers=3)
+    s = build_sample(random.choice(TEMPLATES), min_modifiers=1, max_modifiers=3)
     fps.add(sample_fingerprint(s))
 assert len(fps) > 10, f"Expected >10 unique fingerprints, got {len(fps)}"
-print(f"Test 11 — sample building + validation + fingerprints ({len(fps)}/20 unique): OK ✓")
+print(f"Test 11 — sample building + validation + fingerprints ({len(fps)}/20 unique): OK ✅")
 
 # %%
 #######################################
@@ -443,7 +448,7 @@ print(f"Test 11 — sample building + validation + fingerprints ({len(fps)}/20 u
 #######################################
 random.seed(123)
 template = TEMPLATES[0]
-sample = build_sample(template, key=1, min_modifiers=1, max_modifiers=1)
+sample = build_sample(template, min_modifiers=1, max_modifiers=1)
 assert validate_sample(sample) == [], f"Sample has validation issues: {validate_sample(sample)}"
 
 v = Verifier(
@@ -455,7 +460,7 @@ results = v.verify()
 assert isinstance(results, list)
 assert len(results) == len(sample["verifier_id_list"])
 assert all(isinstance(r, bool) for r in results)
-print("Test 12 — end-to-end generate + verify: OK ✓")
+print("Test 12 — end-to-end generate + verify: OK ✅")
 
 # %%
 #######################################
@@ -546,7 +551,7 @@ v12 = Verifier(
     completion="A palavra \"cachorro\" é mais frequente na lista.",
 )
 assert v12.verify() == [False]
-print("Test 13 — long context verifiers (pass/fail/partial/edge): OK ✓")
+print("Test 13 — long context verifiers (pass/fail/partial/edge): OK ✅")
 
 # %%
 #######################################
@@ -564,13 +569,13 @@ for idx, template in enumerate(LONG_CONTEXT_TEMPLATES[:5]):
     # Word-list tasks use num_words; haystack tasks use documents/num_chars/rng
     if tt.startswith("needle_"):
         continue  # tested separately in haystack tests
-    sample = build_lc_sample(template, key=idx, num_words=30)
+    sample = build_lc_sample(template, num_words=30)
     issues = validate_lc_sample(sample)
     assert issues == [], f"Template {idx} has issues: {issues}"
     assert "completion" not in sample
 
     # Build a correct completion from kwargs
-    kw = sample["kwargs"][0]
+    kw = _parse_kw(sample["kwargs"][0])
     if "expected_words" in kw and kw["expected_words"] is not None:
         completion = "Palavras: " + ", ".join(kw["expected_words"])
     elif "target_word" in kw and kw["target_word"] is not None:
@@ -589,7 +594,7 @@ for idx, template in enumerate(LONG_CONTEXT_TEMPLATES[:5]):
     )
     results = v.verify()
     assert results == [True], f"Template {idx}: expected [True], got {results}"
-print("Test 14 — long context end-to-end (all templates): OK ✓")
+print("Test 14 — long context end-to-end (all templates): OK ✅")
 
 # %%
 #######################################
@@ -679,7 +684,7 @@ v11 = Verifier(
     completion="Qualquer resposta.",
 )
 assert v11.verify() == [True], "Empty expected_values should pass"
-print("Test 15 — haystack verifiers (pass/fail/partial/edge): OK ✓")
+print("Test 15 — haystack verifiers (pass/fail/partial/edge): OK ✅")
 
 # %%
 #######################################
@@ -698,14 +703,14 @@ _hs_docs = load_documents("./data")
 for idx, hs_template in enumerate(HAYSTACK_TEMPLATES):
     random.seed(42 + idx)
     hs_sample = build_hs_sample(
-        hs_template, key=idx, documents=_hs_docs,
+        hs_template, documents=_hs_docs,
         num_chars=2000, rng=random.Random(42 + idx),
     )
     hs_issues = validate_hs_sample(hs_sample)
     assert hs_issues == [], f"Haystack template {idx} has issues: {hs_issues}"
     assert "completion" not in hs_sample
 
-    kw = hs_sample["kwargs"][0]
+    kw = _parse_kw(hs_sample["kwargs"][0])
     values = list(kw["expected_values"].values())[0] if kw["expected_values"] else []
     # diff_keys needs key names in the completion; uuid needs the value only
     tt = hs_template["task_type"]
@@ -723,7 +728,7 @@ for idx, hs_template in enumerate(HAYSTACK_TEMPLATES):
     )
     results = v.verify()
     assert results == [True], f"Haystack template {idx}: expected [True], got {results}"
-print(f"Test 16 — haystack end-to-end ({len(HAYSTACK_TEMPLATES)} templates): OK ✓")
+print(f"Test 16 — haystack end-to-end ({len(HAYSTACK_TEMPLATES)} templates): OK ✅")
 
 # %%
 #######################################
@@ -777,7 +782,7 @@ v6 = Verifier(
 )
 assert v6.verify() == [True]
 
-print("Test 17 — math verifier (pass/fail/edge): OK ✓")
+print("Test 17 — math verifier (pass/fail/edge): OK ✅")
 
 # %%
 #######################################
@@ -788,9 +793,10 @@ from generate_from_math_dataset import (
     validate_sample as validate_math_sample,
 )
 
-sample = build_math_sample("Quanto é 2 + 2?", "4", key=0)
+sample = build_math_sample("Quanto é 2 + 2?", "4")
+assert isinstance(sample["id"], str) and len(sample["id"]) == 32
 assert sample["verifier_id_list"] == ["math:answer_check"]
-assert sample["kwargs"] == [{"expected_answer": "4"}]
+assert _parse_kw(sample["kwargs"][0]) == {"expected_answer": "4"}
 assert validate_math_sample(sample) == []
 
 # Verify it passes with a correct completion
@@ -809,7 +815,7 @@ v2 = Verifier(
 )
 assert v2.verify() == [False]
 
-print("Test 18 — math end-to-end (build + validate + verify): OK ✓")
+print("Test 18 — math end-to-end (build + validate + verify): OK ✅")
 
 # %%
 #######################################
@@ -872,7 +878,7 @@ v6 = Verifier(
     completion='```json\n{"subject": "Reunião", "spam": false, "attachments": true}\n```',
 )
 assert v6.verify() == [True]
-print("Test 19 — email:json_format verifier (pass/fail/edge): OK ✓")
+print("Test 19 — email:json_format verifier (pass/fail/edge): OK ✅")
 
 # %%
 #######################################
@@ -925,7 +931,7 @@ v6 = Verifier(
     completion='```json\n{"subject": "Teste", "sender": "Maria"}\n```',
 )
 assert v6.verify() == [True], "Key order should not matter"
-print("Test 20 — email:schema_keys verifier (pass/fail/edge): OK ✓")
+print("Test 20 — email:schema_keys verifier (pass/fail/edge): OK ✅")
 
 # %%
 #######################################
@@ -994,7 +1000,7 @@ v8 = Verifier(
     completion='{"spam": false, "subject": "Oi"}',
 )
 assert v8.verify() == [True], "field_value should accept raw JSON"
-print("Test 21 — email:field_value verifier (pass/fail/edge): OK ✓")
+print("Test 21 — email:field_value verifier (pass/fail/edge): OK ✅")
 
 # %%
 #######################################
@@ -1017,14 +1023,13 @@ _fields = ["subject", "sender", "spam", "date", "attachments"]
 
 sample_email = build_email_sample(
     email_text=_test_email,
-    key=100,
     fields=_fields,
     injected_values=_injected,
     rng=rng_test,
 )
 
 # Structural assertions
-assert sample_email["key"] == 100
+assert isinstance(sample_email["id"], str) and len(sample_email["id"]) == 32
 assert "email:json_format" in sample_email["verifier_id_list"]
 assert "email:schema_keys" in sample_email["verifier_id_list"]
 assert len(sample_email["verifier_id_list"]) == len(sample_email["kwargs"])
@@ -1042,13 +1047,14 @@ assert fv_count == len(injected_requested), (
 
 # Build a correct completion using the known injected values
 schema_idx = sample_email["verifier_id_list"].index("email:schema_keys")
-req_keys = sample_email["kwargs"][schema_idx]["required_keys"]
+req_keys = _parse_kw(sample_email["kwargs"][schema_idx])["required_keys"]
 correct_obj = {}
 for k in req_keys:
     if k in EMAIL_INJECTED_FIELDS:
         for i, iid in enumerate(sample_email["verifier_id_list"]):
-            if iid == "email:field_value" and sample_email["kwargs"][i]["field_name"] == k:
-                correct_obj[k] = sample_email["kwargs"][i]["expected_value"]
+            _kw_i = _parse_kw(sample_email["kwargs"][i])
+            if iid == "email:field_value" and _kw_i["field_name"] == k:
+                correct_obj[k] = _kw_i["expected_value"]
                 break
     elif k == "subject":
         correct_obj[k] = "Proposta de Parceria"
@@ -1071,7 +1077,7 @@ for i, (iid, res) in enumerate(zip(sample_email["verifier_id_list"], results_ema
     if iid == "email:field_value":
         assert res == True, (
             f"email:field_value[{i}] failed for field "
-            f"'{sample_email['kwargs'][i]['field_name']}': {correct_completion}"
+            f"'{_parse_kw(sample_email['kwargs'][i])['field_name']}': {correct_completion}"
         )
 
 # A wrong completion must fail schema_keys
@@ -1088,7 +1094,7 @@ assert results_wrong[1] == False, "schema_keys should fail for wrong keys"
 for tid in EMAIL_TASK_IDS:
     assert tid in VERIFICATION_REGISTRY, f"Missing registry entry for {tid}"
 
-print("Test 22 — email end-to-end (build + validate + verify): OK ✓")
+print("Test 22 — email end-to-end (build + validate + verify): OK ✅")
 
 # %%
 #######################################
@@ -1186,7 +1192,7 @@ v_tc9 = Verifier(
 )
 assert v_tc9.verify() == [False]
 
-print("Test 23 — tool-call verifiers (pass/fail/edge): OK ✓")
+print("Test 23 — tool-call verifiers (pass/fail/edge): OK ✅")
 
 # %%
 #######################################
@@ -1211,18 +1217,18 @@ rng = random.Random(42)
 for i in range(5):
     tool = rng.choice(all_tools)
     sample = build_tool_call_sample(
-        key=i, tool=tool, all_tools=all_tools,
+        tool=tool, all_tools=all_tools,
         rng=random.Random(42 + i), is_valid=True,
     )
-    assert set(sample.keys()) == {"key", "prompt", "verifier_id_list", "kwargs"}, \
+    assert set(sample.keys()) == {"id", "prompt", "verifier_id_list", "kwargs"}, \
         f"Valid sample has wrong keys: {set(sample.keys())}"
 
 for i in range(5):
     sample = build_tool_call_sample(
-        key=50 + i, tool=None, all_tools=all_tools,
+        tool=None, all_tools=all_tools,
         rng=random.Random(99 + i), is_valid=False,
     )
-    assert set(sample.keys()) == {"key", "prompt", "verifier_id_list", "kwargs"}, \
+    assert set(sample.keys()) == {"id", "prompt", "verifier_id_list", "kwargs"}, \
         f"Refusal sample has wrong keys: {set(sample.keys())}"
 
 # Generate valid samples and verify with a matching completion
@@ -1231,16 +1237,16 @@ for i in range(10):
     tool = rng2.choice(all_tools)
     sample_rng = random.Random(42 + i)
     sample = build_tool_call_sample(
-        key=i, tool=tool, all_tools=all_tools,
+        tool=tool, all_tools=all_tools,
         rng=sample_rng, is_valid=True,
     )
     issues = validate_tool_call_sample(sample)
     assert not issues, f"Valid sample {i} has issues: {issues}"
 
     # Build a completion that matches the expected tool call
-    expected_name = sample["kwargs"][1]["expected_name"]
-    expected_arg_keys = sample["kwargs"][2]["required_arg_keys"]
-    expected_arg_types = sample["kwargs"][3]["expected_arg_types"]
+    expected_name = _parse_kw(sample["kwargs"][1])["expected_name"]
+    expected_arg_keys = _parse_kw(sample["kwargs"][2])["required_arg_keys"]
+    expected_arg_types = _parse_kw(sample["kwargs"][3])["expected_arg_types"]
     # Generate arguments that satisfy the verifiers (include all typed args)
     args = {}
     for key in expected_arg_types:
@@ -1270,7 +1276,7 @@ for i in range(10):
 # Generate and verify refusal samples
 for i in range(10):
     sample = build_tool_call_sample(
-        key=100 + i, tool=None, all_tools=all_tools,
+        tool=None, all_tools=all_tools,
         rng=random.Random(99 + i), is_valid=False,
     )
     issues = validate_tool_call_sample(sample)
@@ -1294,7 +1300,6 @@ rng3 = random.Random(42)
 for i in range(50):
     tool = rng3.choice(all_tools)
     sample = build_tool_call_sample(
-        key=200 + i,
         tool=tool,
         all_tools=all_tools,
         rng=random.Random(200 + i),
@@ -1307,12 +1312,72 @@ assert len(fps) == 50, f"Expected 50 unique fingerprints, got {len(fps)}"
 for tid in TOOL_CALL_TASK_IDS:
     assert tid in VERIFICATION_REGISTRY, f"Missing registry entry for {tid}"
 
-print("Test 24 — tool-call end-to-end (generate + validate + verify): OK ✓")
+print("Test 24 — tool-call end-to-end (generate + validate + verify): OK ✅")
+
+# %%
+#######################################
+# 25. Thinking format verifier — enable_thinking flag
+#######################################
+# 25a. enable_thinking=True, valid <think> block → first result True
+v_think = Verifier(
+    verifier_id_list=["punctuation:no_comma"],
+    kwargs=[{}],
+    completion="<think>\nPreciso responder sem vírgulas.\n</think>\nResposta sem pontuação extra.",
+    enable_thinking=True,
+)
+r_think = v_think.verify()
+assert len(r_think) == 2, f"Expected 2 results, got {len(r_think)}"
+assert r_think[0] == True, "thinking_format should pass with non-empty <think> block"
+assert r_think[1] == True, "no_comma should pass"
+
+# 25b. enable_thinking=True, missing <think> tags → first result False
+v_think2 = Verifier(
+    verifier_id_list=["punctuation:no_comma"],
+    kwargs=[{}],
+    completion="Resposta direta sem bloco de raciocínio.",
+    enable_thinking=True,
+)
+r_think2 = v_think2.verify()
+assert r_think2[0] == False, "thinking_format should fail without <think> tags"
+assert r_think2[1] == True, "no_comma should still pass"
+
+# 25c. enable_thinking=True, empty <think></think> tags → fail
+v_think3 = Verifier(
+    verifier_id_list=[],
+    kwargs=[],
+    completion="<think>   </think>\nResposta.",
+    enable_thinking=True,
+)
+assert v_think3.verify() == [False], "Empty <think> tags should fail"
+
+# 25d. enable_thinking=True, <think> with content → pass
+v_think4 = Verifier(
+    verifier_id_list=[],
+    kwargs=[],
+    completion="<think>Vou pensar sobre isso.</think>\nA resposta é 42.",
+    enable_thinking=True,
+)
+assert v_think4.verify() == [True]
+
+# 25e. enable_thinking=False (default) — no extra check prepended
+v_think5 = Verifier(
+    verifier_id_list=["punctuation:no_comma"],
+    kwargs=[{}],
+    completion="Resposta simples sem vírgulas.",
+)
+r_think5 = v_think5.verify()
+assert len(r_think5) == 1, "Without enable_thinking, result length should match verifier_id_list"
+assert r_think5 == [True]
+
+# 25f. Direct checker in registry
+assert "reasoning:thinking_format" in VERIFICATION_REGISTRY
+
+print("Test 25 — thinking format verifier (enable_thinking flag): OK ✅")
 
 # %%
 #######################################
 # Summary
 #######################################
 print("\n" + "=" * 40)
-print("All tests passed!")
+print("All tests passed 🎉🎉🎉")
 print("=" * 40)

--- a/gym/verifier.py
+++ b/gym/verifier.py
@@ -19,6 +19,8 @@ Usage:
     # [True, True]
 """
 
+import json
+
 from verifiers import (
     BulletListChecker,
     CapitalLettersPortugueseChecker,
@@ -55,6 +57,7 @@ from verifiers import (
     RepeatPromptThenAnswer,
     ResponseLanguageChecker,
     SectionChecker,
+    ThinkingFormatChecker,
     TitleChecker,
     ToolCallArgsKeysChecker,
     ToolCallArgsTypesChecker,
@@ -117,6 +120,8 @@ VERIFICATION_REGISTRY = {
     "tool_call:args_keys": ToolCallArgsKeysChecker,
     "tool_call:args_types": ToolCallArgsTypesChecker,
     "tool_call:refusal": ToolCallRefusalChecker,
+    # Reasoning / thinking format
+    "reasoning:thinking_format": ThinkingFormatChecker,
 }
 
 
@@ -131,21 +136,39 @@ class Verifier:
         completion: The model-generated response to evaluate.
     """
 
-    def __init__(self, verifier_id_list, kwargs, completion):
+    def __init__(self, verifier_id_list, kwargs, completion, enable_thinking=False):
         self.verifier_id_list = verifier_id_list
         self.kwargs = kwargs
         self.completion = completion
+        self.enable_thinking = enable_thinking
 
     def verify(self):
-        """Run all verifiers and return a list of booleans."""
+        """Run all verifiers and return a list of booleans.
+
+        If *enable_thinking* is True, an extra ``reasoning:thinking_format``
+        check is prepended to the results list.
+        """
         results = []
+        if self.enable_thinking:
+            results.append(
+                self._verify_one("reasoning:thinking_format", {})
+            )
         for i, verifier_id in enumerate(self.verifier_id_list):
             passed = self._verify_one(verifier_id, self.kwargs[i])
             results.append(passed)
         return results
 
+    @staticmethod
+    def _parse_kwargs(raw_kwargs):
+        """Accept a dict or a JSON string and return a dict."""
+        if isinstance(raw_kwargs, str):
+            raw_kwargs = json.loads(raw_kwargs)
+        return raw_kwargs
+
     def _verify_one(self, verifier_id, raw_kwargs):
         """Instantiate the checker, build its description, and run verification."""
+        raw_kwargs = self._parse_kwargs(raw_kwargs)
+
         cls = VERIFICATION_REGISTRY.get(verifier_id)
         if cls is None:
             raise ValueError(f"Unknown verifier ID: {verifier_id}")

--- a/gym/verifiers.py
+++ b/gym/verifiers.py
@@ -2152,3 +2152,27 @@ class ToolCallRefusalChecker(TaskVerifier):
             return False
         word_count = len(value.split())
         return word_count >= self._min_words
+
+
+class ThinkingFormatChecker(TaskVerifier):
+    """Check that the completion contains non-empty <think>...</think> tags."""
+
+    _THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+
+    def build_description(self):
+        return (
+            "A resposta deve incluir um bloco de raciocínio dentro das tags "
+            "<think>...</think> antes da resposta final."
+        )
+
+    def get_instruction_args(self):
+        return {}
+
+    def get_instruction_args_keys(self):
+        return []
+
+    def check_following(self, value):
+        match = self._THINK_RE.search(value)
+        if match is None:
+            return False
+        return bool(match.group(1).strip())


### PR DESCRIPTION
This pull request updates the sample generation scripts for emails, instructions, and long-context tasks. The main changes include switching from integer keys to deterministic hash-based sample IDs, serializing `kwargs` as JSON strings, removing the unused `--start_key` argument, and updating usage examples to reflect larger default dataset sizes and output in `.jsonl` format.
