### PR TITLE
Updated the `DistributedEnvironment` so it has support for out-of-SLURM envs.

### DIFF
--- a/ddp/utils.py
+++ b/ddp/utils.py
@@ -5,7 +5,7 @@ Provides:
     - compute_training_schedule:    gradient accumulation steps and step counts
     - setup_triton_cache:           per-rank Triton cache with cleanup
     - StructuredTrainingLogger:     structured metadata/stats file writer
-    - DistributedEnvironment:       SLURM-aware DDP environment manager
+    - DistributedEnvironment:       DDP environment manager (SLURM, torchrun, or local)
     - load_checkpoint_state:        load optimizer and training state from checkpoint
     - initialize_wandb:             login and init W&B run
     - create_emissions_tracker:     create and start a CodeCarbon EmissionsTracker
@@ -86,48 +86,70 @@ class StructuredTrainingLogger:
 
 
 class DistributedEnvironment:
-    """Manages the distributed training environment setup and cleanup."""
+    """Manages the distributed training environment setup and cleanup.
+
+    Discovery order for world size and rank:
+        1. SLURM variables  (SLURM_NTASKS / SLURM_PROCID)
+        2. PyTorch launcher variables (WORLD_SIZE / RANK / LOCAL_RANK)
+        3. Local fallback: use available GPUs or CPU
+    """
 
     def __init__(self, logger):
 
         if "SLURM_NTASKS" in os.environ and "SLURM_PROCID" in os.environ:
-
-            # SLURM_NTASKS is the total number of processes (aka, world size).
+            # SLURM cluster
             self.world_size = int(os.environ["SLURM_NTASKS"])
+            self.rank = int(os.environ["SLURM_PROCID"])
+            self.local_rank = int(os.environ.get("SLURM_LOCALID", self.rank % max(torch.cuda.device_count(), 1)))
 
-            if self.world_size > 1:
+        elif "WORLD_SIZE" in os.environ and "RANK" in os.environ:
+            # torchrun / torch.distributed.launch
+            self.world_size = int(os.environ["WORLD_SIZE"])
+            self.rank = int(os.environ["RANK"])
+            self.local_rank = int(os.environ.get("LOCAL_RANK", 0))
 
-                # SLURM_PROCID is the rank of the current process in SLURM.
-                self.rank = int(os.environ['SLURM_PROCID'])
+        else:
+            # Local single-process fallback (single GPU or CPU)
+            self.world_size = 1
+            self.rank = 0
+            self.local_rank = 0
 
+        if self.world_size > 1:
+            # Multi-process distributed training.
+            if torch.cuda.is_available():
                 # [PyTorch Distributed Documentation](https://docs.pytorch.org/docs/stable/distributed.html)
                 dist.init_process_group(
                     backend="nccl",
-                    world_size=self.world_size, 
+                    world_size=self.world_size,
                     rank=self.rank,
-                    device_id=self.rank % torch.cuda.device_count()
+                    device_id=self.local_rank,
                 )
-
-                # Set the device to the current rank.
-                self.device = f"cuda:{self.rank % torch.cuda.device_count()}"
+                self.device = f"cuda:{self.local_rank}"
                 torch.cuda.set_device(self.device)
-                # The first process is the master process.
-                self.master_process = self.rank == 0
-                self.ddp = True
-                if self.master_process:
-                    logger.info(f"Running DDP via '{dist.get_backend()}' backend. Logging process: {self.rank}. World size: {self.world_size}.")
-            
             else:
-                # If the world size is 1, then we are not using distributed training.
-                self.rank = 0
-                self.device = "cuda:0"
-                torch.cuda.set_device(self.device)
-                self.master_process = True
-                self.ddp = False
-                logger.info("Running single process training.")
+                dist.init_process_group(
+                    backend="gloo",
+                    world_size=self.world_size,
+                    rank=self.rank,
+                )
+                self.device = "cpu"
+
+            self.master_process = self.rank == 0
+            self.ddp = True
+            if self.master_process:
+                logger.info(f"Running DDP via '{dist.get_backend()}' backend. Logging process: {self.rank}. World size: {self.world_size}.")
 
         else:
-            raise ValueError("SLURM_NTASKS or SLURM_PROCID environment variable is not set. This script is intended to be run with SLURM.")
+            # Single-process training (1 GPU or CPU).
+            self.rank = 0
+            if torch.cuda.is_available():
+                self.device = "cuda:0"
+                torch.cuda.set_device(self.device)
+            else:
+                self.device = "cpu"
+            self.master_process = True
+            self.ddp = False
+            logger.info(f"Running single process training on {self.device}.")
 
         self.device_type = "cuda" if self.device.startswith("cuda") else "cpu"
 

--- a/fsdp/utils.py
+++ b/fsdp/utils.py
@@ -86,48 +86,70 @@ class StructuredTrainingLogger:
 
 
 class DistributedEnvironment:
-    """Manages the distributed training environment setup and cleanup."""
+    """Manages the distributed training environment setup and cleanup.
+
+    Discovery order for world size and rank:
+        1. SLURM variables  (SLURM_NTASKS / SLURM_PROCID)
+        2. PyTorch launcher variables (WORLD_SIZE / RANK / LOCAL_RANK)
+        3. Local fallback: use available GPUs or CPU
+    """
 
     def __init__(self, logger):
 
         if "SLURM_NTASKS" in os.environ and "SLURM_PROCID" in os.environ:
-
-            # SLURM_NTASKS is the total number of processes (aka, world size).
+            # SLURM cluster
             self.world_size = int(os.environ["SLURM_NTASKS"])
+            self.rank = int(os.environ["SLURM_PROCID"])
+            self.local_rank = int(os.environ.get("SLURM_LOCALID", self.rank % max(torch.cuda.device_count(), 1)))
 
-            if self.world_size > 1:
+        elif "WORLD_SIZE" in os.environ and "RANK" in os.environ:
+            # torchrun / torch.distributed.launch
+            self.world_size = int(os.environ["WORLD_SIZE"])
+            self.rank = int(os.environ["RANK"])
+            self.local_rank = int(os.environ.get("LOCAL_RANK", 0))
 
-                # SLURM_PROCID is the rank of the current process in SLURM.
-                self.rank = int(os.environ['SLURM_PROCID'])
+        else:
+            # Local single-process fallback (single GPU or CPU)
+            self.world_size = 1
+            self.rank = 0
+            self.local_rank = 0
 
+        if self.world_size > 1:
+            # Multi-process distributed training.
+            if torch.cuda.is_available():
                 # [PyTorch Distributed Documentation](https://docs.pytorch.org/docs/stable/distributed.html)
                 dist.init_process_group(
                     backend="nccl",
-                    world_size=self.world_size, 
+                    world_size=self.world_size,
                     rank=self.rank,
-                    device_id=self.rank % torch.cuda.device_count()
+                    device_id=self.local_rank,
                 )
-
-                # Set the device to the current rank.
-                self.device = f"cuda:{self.rank % torch.cuda.device_count()}"
+                self.device = f"cuda:{self.local_rank}"
                 torch.cuda.set_device(self.device)
-                # The first process is the master process.
-                self.master_process = self.rank == 0
-                self.fsdp = True
-                if self.master_process:
-                    logger.info(f"Running FSDP via '{dist.get_backend()}' backend. Logging process: {self.rank}. World size: {self.world_size}.")
-            
             else:
-                # If the world size is 1, then we are not using distributed training.
-                self.rank = 0
-                self.device = "cuda:0"
-                torch.cuda.set_device(self.device)
-                self.master_process = True
-                self.fsdp = False
-                logger.info("Running single process training.")
+                dist.init_process_group(
+                    backend="gloo",
+                    world_size=self.world_size,
+                    rank=self.rank,
+                )
+                self.device = "cpu"
+
+            self.master_process = self.rank == 0
+            self.ddp = True
+            if self.master_process:
+                logger.info(f"Running DDP via '{dist.get_backend()}' backend. Logging process: {self.rank}. World size: {self.world_size}.")
 
         else:
-            raise ValueError("SLURM_NTASKS or SLURM_PROCID environment variable is not set. This script is intended to be run with SLURM.")
+            # Single-process training (1 GPU or CPU).
+            self.rank = 0
+            if torch.cuda.is_available():
+                self.device = "cuda:0"
+                torch.cuda.set_device(self.device)
+            else:
+                self.device = "cpu"
+            self.master_process = True
+            self.ddp = False
+            logger.info(f"Running single process training on {self.device}.")
 
         self.device_type = "cuda" if self.device.startswith("cuda") else "cpu"
 
@@ -144,7 +166,7 @@ class DistributedEnvironment:
 
     def cleanup(self):
         """Clean up the distributed environment."""
-        if self.fsdp:
+        if self.ddp:
             dist.destroy_process_group()
 
 

--- a/tests/tests_ddp.py
+++ b/tests/tests_ddp.py
@@ -1468,20 +1468,43 @@ def test_checkpoint_already_validated_positive():
         shutil.rmtree(tmpdir)
 
 
-def test_distributed_environment_missing_slurm_vars():
-    """DistributedEnvironment raises ValueError when SLURM vars are missing."""
+def test_distributed_environment_local_fallback():
+    """DistributedEnvironment falls back to single-process mode when no SLURM/torchrun vars are set."""
     saved = {}
-    for key in ("SLURM_NTASKS", "SLURM_PROCID"):
+    for key in ("SLURM_NTASKS", "SLURM_PROCID", "WORLD_SIZE", "RANK", "LOCAL_RANK"):
         if key in os.environ:
             saved[key] = os.environ.pop(key)
     try:
-        raised = False
-        try:
-            DistributedEnvironment(logging.getLogger("test"))
-        except ValueError:
-            raised = True
-        assert raised
+        env = DistributedEnvironment(logging.getLogger("test"))
+        assert env.world_size == 1
+        assert env.rank == 0
+        assert env.local_rank == 0
+        assert env.master_process is True
+        assert env.ddp is False
+        assert env.device in ("cpu", "cuda:0")
     finally:
+        os.environ.update(saved)
+
+
+def test_distributed_environment_torchrun_vars():
+    """DistributedEnvironment picks up WORLD_SIZE/RANK/LOCAL_RANK when SLURM vars are absent."""
+    saved = {}
+    for key in ("SLURM_NTASKS", "SLURM_PROCID", "WORLD_SIZE", "RANK", "LOCAL_RANK"):
+        if key in os.environ:
+            saved[key] = os.environ.pop(key)
+    # Simulate a single-process torchrun launch (world_size=1).
+    os.environ["WORLD_SIZE"] = "1"
+    os.environ["RANK"] = "0"
+    os.environ["LOCAL_RANK"] = "0"
+    try:
+        env = DistributedEnvironment(logging.getLogger("test"))
+        assert env.world_size == 1
+        assert env.rank == 0
+        assert env.local_rank == 0
+        assert env.ddp is False
+    finally:
+        for key in ("WORLD_SIZE", "RANK", "LOCAL_RANK"):
+            os.environ.pop(key, None)
         os.environ.update(saved)
 
 
@@ -1614,7 +1637,8 @@ for _fn in [
     test_cleanup_log_file_missing_file,
     test_checkpoint_already_validated_no_dir,
     test_checkpoint_already_validated_positive,
-    test_distributed_environment_missing_slurm_vars,
+    test_distributed_environment_local_fallback,
+    test_distributed_environment_torchrun_vars,
     test_distributed_environment_seed_everything,
     test_load_checkpoint_state_no_resume,
     test_load_checkpoint_state_resume,

--- a/tests/tests_fsdp.py
+++ b/tests/tests_fsdp.py
@@ -1534,20 +1534,43 @@ def test_checkpoint_already_validated_positive():
         shutil.rmtree(tmpdir)
 
 
-def test_distributed_environment_missing_slurm_vars():
-    """DistributedEnvironment raises ValueError when SLURM vars are missing."""
+def test_distributed_environment_local_fallback():
+    """DistributedEnvironment falls back to single-process mode when no SLURM/torchrun vars are set."""
     saved = {}
-    for key in ("SLURM_NTASKS", "SLURM_PROCID"):
+    for key in ("SLURM_NTASKS", "SLURM_PROCID", "WORLD_SIZE", "RANK", "LOCAL_RANK"):
         if key in os.environ:
             saved[key] = os.environ.pop(key)
     try:
-        raised = False
-        try:
-            DistributedEnvironment(logging.getLogger("test"))
-        except ValueError:
-            raised = True
-        assert raised
+        env = DistributedEnvironment(logging.getLogger("test"))
+        assert env.world_size == 1
+        assert env.rank == 0
+        assert env.local_rank == 0
+        assert env.master_process is True
+        assert env.ddp is False
+        assert env.device in ("cpu", "cuda:0")
     finally:
+        os.environ.update(saved)
+
+
+def test_distributed_environment_torchrun_vars():
+    """DistributedEnvironment picks up WORLD_SIZE/RANK/LOCAL_RANK when SLURM vars are absent."""
+    saved = {}
+    for key in ("SLURM_NTASKS", "SLURM_PROCID", "WORLD_SIZE", "RANK", "LOCAL_RANK"):
+        if key in os.environ:
+            saved[key] = os.environ.pop(key)
+    # Simulate a single-process torchrun launch (world_size=1).
+    os.environ["WORLD_SIZE"] = "1"
+    os.environ["RANK"] = "0"
+    os.environ["LOCAL_RANK"] = "0"
+    try:
+        env = DistributedEnvironment(logging.getLogger("test"))
+        assert env.world_size == 1
+        assert env.rank == 0
+        assert env.local_rank == 0
+        assert env.ddp is False
+    finally:
+        for key in ("WORLD_SIZE", "RANK", "LOCAL_RANK"):
+            os.environ.pop(key, None)
         os.environ.update(saved)
 
 
@@ -1680,7 +1703,8 @@ for _fn in [
     test_cleanup_log_file_missing_file,
     test_checkpoint_already_validated_no_dir,
     test_checkpoint_already_validated_positive,
-    test_distributed_environment_missing_slurm_vars,
+    test_distributed_environment_local_fallback,
+    test_distributed_environment_torchrun_vars,
     test_distributed_environment_seed_everything,
     test_load_checkpoint_state_no_resume,
     test_load_checkpoint_state_resume,


### PR DESCRIPTION
This pull request improves the flexibility of the distributed environment setup in both DDP and FSDP utilities. The `DistributedEnvironment` class is refactored to support not only SLURM-based clusters but also PyTorch's `torchrun` launcher and local (single-process) execution. The changes also update tests to cover these new scenarios and remove the requirement for SLURM-specific environment variables.

- Refactored the `DistributedEnvironment` class in both `ddp/utils.py` and `fsdp/utils.py` to detect and support three modes: SLURM clusters, PyTorch's `torchrun`/`torch.distributed.launch`, and a local fallback for single-process (GPU or CPU) runs. The class now sets `world_size`, `rank`, and `local_rank` based on available environment variables, with a clear discovery order and improved device-assignment logic.

- Replaced the test that expected a failure when SLURM variables were missing with new tests that verify correct fallback to local mode and correct handling of torchrun environment variables in both DDP and FSDP test suites.