### PR TITLE
Update dtype, dependencies, and MFU calculations

### DIFF
--- a/data/filters/train_classifier.py
+++ b/data/filters/train_classifier.py
@@ -161,7 +161,7 @@ def main(args):
         "label2id": {args.id_label: 0},
         "trust_remote_code": True,
         "use_cache": True if not args.gradient_checkpointing else False,
-        "torch_dtype": torch.bfloat16 if args.bf16 else torch.float32,
+        "dtype": torch.bfloat16 if args.bf16 else torch.float32,
         "device_map":{'':state.process_index},
     }
     

--- a/distributed/mfu.py
+++ b/distributed/mfu.py
@@ -35,6 +35,9 @@ class MFUContext:
     vocab_size: int = 0
     intermediate_size: int = 0
     layer_types: Tuple[str, ...] = ()
+    # Number of K/V heads for grouped-query attention. When 0 or equal to
+    # `num_attention_heads`, attention behaves as multi-head attention (MHA).
+    num_key_value_heads: int = 0
     
     # Mamba2 parameters
     mamba_d_state: int = 0
@@ -51,6 +54,13 @@ class MFUContext:
     linear_value_head_dim: int = 0
     linear_conv_kernel_dim: int = 4
     linear_chunk_size: int = 256
+
+    # MoE parameters (used by hybrid / mamba paths when num_experts_per_tok > 0).
+    # The dense_transformer / moe paths instead derive active FLOPs from
+    # `num_parameters`, which the trainer is expected to set to the active count.
+    num_experts_per_tok: int = 0
+    moe_intermediate_size: int = 0      # per-routed-expert MLP intermediate size
+    shared_intermediate_size: int = 0   # always-active shared expert intermediate size
 
 
 @dataclass(frozen=True)
@@ -74,6 +84,28 @@ def _dense_transformer_mfu(context, micro_batch_size, gradient_accumulation_step
     flops_per_iter = flops_per_fwdbwd * (micro_batch_size * gradient_accumulation_steps)
     flops_achieved = flops_per_iter / dt
     return (flops_achieved / context.peak_flops) * 100
+
+def _active_mlp_macs(ctx):
+    """
+    Per-token MACs for the active part of the MLP block in a single layer.
+
+    Handles three configurations:
+      * Dense SwiGLU MLP (default): 3 * d * intermediate_size.
+      * Top-k routed MoE (e.g. Qwen-MoE): only the `num_experts_per_tok`
+        routed experts contribute, each with `moe_intermediate_size`.
+      * Routed MoE + shared expert(s) (e.g. GraniteMoeHybrid, DeepSeek-V2/V3):
+        adds a constant `shared_intermediate_size` term on top of the routed
+        contribution.
+    """
+    d = ctx.hidden_size
+    if ctx.num_experts_per_tok > 0 and ctx.moe_intermediate_size > 0:
+        # SwiGLU per expert: gate + up + down projections.
+        routed = 3 * d * ctx.moe_intermediate_size * ctx.num_experts_per_tok
+        # Shared expert(s) are dense and always active.
+        shared = 3 * d * ctx.shared_intermediate_size
+        return routed + shared
+    return 3 * d * ctx.intermediate_size
+
 
 def _mamba_layer_macs(ctx):
     """
@@ -100,8 +132,8 @@ def _mamba_layer_macs(ctx):
     intra_chunk = 2 * ctx.mamba_chunk_size * e
     # Inter-chunk state passing                                (Eq. 11)
     inter_chunk = 2 * e * n
-    # MLP (SwiGLU: gate + up + down projections)               (Eq. 9: 3d.d_MLP)
-    mlp = 3 * d * ctx.intermediate_size
+    # MLP (SwiGLU). MoE-aware: only active experts contribute.   (Eq. 9: 3d.d_MLP)
+    mlp = _active_mlp_macs(ctx)
 
     return in_proj + conv + out_proj + intra_chunk + inter_chunk + mlp
 
@@ -109,12 +141,21 @@ def _mamba_layer_macs(ctx):
 def _attention_layer_macs(ctx):
     """
     MACs per token for a full (causal) attention layer.
+
+    Supports grouped-query attention (GQA): when `num_key_value_heads` is set
+    and smaller than `num_attention_heads`, the K and V projection costs are
+    scaled down by `num_key_value_heads / num_attention_heads`.
     """
     d = ctx.hidden_size
     s = ctx.sequence_length
-    projections = 4 * d * d                     # Q, K, V, O projections
-    attention   = d * s                         # QK^T + attn.V  (causal avg)
-    mlp         = 3 * d * ctx.intermediate_size # SwiGLU MLP
+    h = ctx.num_attention_heads
+    kv_h = ctx.num_key_value_heads if ctx.num_key_value_heads > 0 else h
+    q_dim = h * ctx.head_dim       # query projection output dim
+    kv_dim = kv_h * ctx.head_dim   # key / value projection output dim (shared across grouped heads)
+    # Q + O projections are full d->d; K and V are d->kv_dim each.
+    projections = 2 * d * q_dim + 2 * d * kv_dim
+    attention   = d * s            # QK^T + attn.V  (causal avg, dominated by query dim)
+    mlp         = _active_mlp_macs(ctx)
     return projections + attention + mlp
 
 
@@ -142,8 +183,8 @@ def _linear_attention_layer_macs(ctx):
     intra_chunk = L * (3 * k + 2 * v)
     # Inter-chunk state passing: 3 mat-muls of size k_h x v_h per head (Eq. 10)
     inter_chunk = 3 * k * v // h if h > 0 else 0
-    # MLP                                                              (Eq. 8)
-    mlp = 3 * d * ctx.intermediate_size
+    # MLP, MoE-aware.                                                 (Eq. 8)
+    mlp = _active_mlp_macs(ctx)
 
     return projections + conv + gate_out + intra_chunk + inter_chunk + mlp
 
@@ -202,6 +243,16 @@ MFU_REGISTRY = {
     "dense_transformer": _dense_transformer_mfu,
     "mamba": _mamba_mfu,
     "hybrid": _mamba_mfu,
+    # Pure MoE transformers reuse the dense-transformer formula; the trainer
+    # passes the *active* parameter count (params actually used per token)
+    # as `num_parameters`. See _compute_active_trainable_params in model_setup.py.
+    "moe": _dense_transformer_mfu,
+    # MoE-hybrid (e.g. GraniteMoeHybrid: mamba + attention layers, with a
+    # routed-MoE MLP on every layer, optionally plus a shared expert).
+    # Reuses the structural mamba/hybrid formula; the per-layer MLP term is
+    # MoE-aware via `num_experts_per_tok`, `moe_intermediate_size`, and
+    # `shared_intermediate_size` on the MFUContext.
+    "moe_hybrid": _mamba_mfu,
 }
 
 
@@ -225,6 +276,7 @@ def create_mfu_context(args, hardware, num_parameters):
         vocab_size=getattr(args, 'vocab_size', 0),
         intermediate_size=getattr(args, 'intermediate_size', 0),
         layer_types=layer_types,
+        num_key_value_heads=getattr(args, 'num_key_value_heads', 0) or 0,
         # Mamba2
         mamba_d_state=getattr(args, 'mamba_d_state', 0),
         mamba_chunk_size=getattr(args, 'mamba_chunk_size', 256),
@@ -238,6 +290,10 @@ def create_mfu_context(args, hardware, num_parameters):
         linear_key_head_dim=getattr(args, 'linear_key_head_dim', 0),
         linear_value_head_dim=getattr(args, 'linear_value_head_dim', 0),
         linear_conv_kernel_dim=getattr(args, 'linear_conv_kernel_dim', 4),
+        # MoE
+        num_experts_per_tok=getattr(args, 'num_experts_per_tok', 0) or 0,
+        moe_intermediate_size=getattr(args, 'moe_intermediate_size', 0) or 0,
+        shared_intermediate_size=getattr(args, 'shared_intermediate_size', 0) or 0,
     )
 
 

--- a/distributed/model_setup.py
+++ b/distributed/model_setup.py
@@ -135,7 +135,7 @@ def _build_model_from_config(args, tokenizer, precision, distributed_config=None
         "eos_token_id": tokenizer.eos_token_id,
         "pad_token_id": tokenizer.pad_token_id,
         "unk_token_id": tokenizer.unk_token_id,
-        "torch_dtype": precision,
+        "dtype": precision,
     }
 
     config = AutoConfig.from_pretrained(
@@ -164,7 +164,7 @@ def _load_model(args, tokenizer, precision, master_process, logger=None, file_lo
     if checkpoint_path is not None:
         model = AutoModelForCausalLM.from_pretrained(
             checkpoint_path,
-            torch_dtype=precision,
+            dtype=precision,
             attn_implementation=args.attn_implementation,
             cache_dir=args.cache_dir,
             **({"distributed_config": distributed_config} if distributed_config is not None else {}),
@@ -226,7 +226,7 @@ def _load_model(args, tokenizer, precision, master_process, logger=None, file_lo
 
     model = AutoModelForCausalLM.from_pretrained(
         args.base_model,
-        torch_dtype=precision,
+        dtype=precision,
         attn_implementation=args.attn_implementation,
         cache_dir=args.cache_dir,
         config=config,
@@ -397,11 +397,50 @@ def prepare_training_components(args, device, master_process, logger=None, file_
         model.config, 'head_dim',
         model.config.hidden_size // model.config.num_attention_heads,
     )
+    # GQA: fall back to num_attention_heads (MHA) when not specified.
+    args.num_key_value_heads = getattr(
+        model.config, 'num_key_value_heads', model.config.num_attention_heads,
+    )
+
+    # Architecture fields used by the structural (mamba/hybrid/moe_hybrid) MFU path.
+    # These are no-ops for the dense_transformer path.
+    args.hidden_size = getattr(model.config, 'hidden_size', 0)
+    args.intermediate_size = getattr(model.config, 'intermediate_size', 0)
+    args.layer_types = tuple(getattr(model.config, 'layer_types', ()) or ())
+    # Mamba2 hyperparameters (only present on mamba/hybrid configs).
+    args.mamba_d_state = getattr(model.config, 'mamba_d_state', 0)
+    args.mamba_chunk_size = getattr(model.config, 'mamba_chunk_size', 256)
+    args.mamba_d_conv = getattr(model.config, 'mamba_d_conv', 4)
+    args.mamba_n_heads = getattr(model.config, 'mamba_n_heads', 0)
+    args.mamba_d_head = getattr(model.config, 'mamba_d_head', 0)
+    args.mamba_n_groups = getattr(model.config, 'mamba_n_groups', 1)
+
+    # MoE fields. The *_intermediate_size selection mirrors the convention used
+    # in _compute_active_trainable_params: prefer `moe_intermediate_size` (Qwen)
+    # and fall back to `intermediate_size` (Granite-MoE-Hybrid, where it is
+    # already the per-expert size).
+    _num_experts = (
+        getattr(model.config, 'num_experts', None)
+        or getattr(model.config, 'num_local_experts', None)
+        or 0
+    )
+    if _num_experts and _num_experts > 1:
+        args.num_experts_per_tok = getattr(model.config, 'num_experts_per_tok', 0) or 0
+        args.moe_intermediate_size = (
+            getattr(model.config, 'moe_intermediate_size', None)
+            or getattr(model.config, 'intermediate_size', 0)
+            or 0
+        )
+        args.shared_intermediate_size = getattr(model.config, 'shared_intermediate_size', 0) or 0
+    else:
+        args.num_experts_per_tok = 0
+        args.moe_intermediate_size = 0
+        args.shared_intermediate_size = 0
 
     tokenizer.model_max_length = model.config.max_position_embeddings
 
     # Warn if training a hybrid/mamba model without the optimized CUDA kernels.
-    if args.mfu_type in ("mamba", "hybrid"):
+    if args.mfu_type in ("mamba", "hybrid", "moe_hybrid"):
         _mamba_kernels_available = True
         try:
             from mamba_ssm import Mamba

--- a/distributed/specifications.py
+++ b/distributed/specifications.py
@@ -202,8 +202,13 @@ class TrainingArguments:
         default="dense_transformer",
         metadata={"help": (
             "The MFU calculation strategy to use. "
-            "Options currently include: `dense_transformer`, `mamba`, and `hybrid` (a combination of the previous two). "
-            "This is intended to be extended for other architectures such as MoE or Mamba."
+            "Options currently include: `dense_transformer`, `moe`, `mamba`, `hybrid` "
+            "(mamba + attention), and `moe_hybrid` (mamba + attention + routed-MoE MLPs, "
+            "optionally with shared experts, e.g., GraniteMoeHybrid). "
+            "For `moe`, the trainer uses the active parameter count (parameters actually "
+            "used per token) instead of the total parameter count when computing MFU. "
+            "For `moe_hybrid`, the per-layer MLP FLOPs are computed structurally from "
+            "`num_experts_per_tok`, `moe_intermediate_size`, and `shared_intermediate_size`."
         )},
     )
 
@@ -298,7 +303,7 @@ class TrainingArguments:
         default=False,
         metadata={"help": (
             "Whether to use the Liger kernels for training."
-            "The promise is to increase multi-GPU training throughput by 20% and reduce memory usage by 60%"
+            "The promise is to increase multi-GPU training throughput by 20% and reduce memory usage by 60%."
             "WARNING: Not all models are compatible with this set of kernels."
             "Check the documentation for more information."
             "https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/transformers/monkey_patch.py#L1853"

--- a/merge/resize_embedding_layer.py
+++ b/merge/resize_embedding_layer.py
@@ -33,7 +33,7 @@ def load_model_and_tokenizer(model_path: str, dtype: str = "bfloat16") -> Tuple[
 		
 		print(f"Loading model from {model_path} (dtype={dtype}) ...")
 		torch_dtype = getattr(torch, dtype)
-		model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype)
+		model = AutoModelForCausalLM.from_pretrained(model_path, dtype=torch_dtype)
 		
 		return tokenizer, model
 	except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ data = [
     "pyyaml",
 ]
 # NOTE: flash_attn requires --no-build-isolation and must be installed separately:
-#   pip3 install flash_attn==2.8.2 --no-build-isolation
+#   pip3 install flash_attn==2.8.3 --no-build-isolation
 distributed = [
     "wheel==0.45.1",
     "packaging==25.0",
@@ -31,14 +31,14 @@ distributed = [
     "torchaudio==2.8.0",
     "torchvision==0.23.0",
     "numpy==2.3.2",
-    "transformers==4.53.2",
+    "transformers==5.6.2",
     "datasets==4.0.0",
     "sentencepiece==0.2.0",
     "accelerate==1.9.0",
     "codecarbon==3.0.6",
     "wandb==0.21.0",
     "pyyaml==6.0.2",
-    "liger-kernel==0.6.1",
+    "liger-kernel==0.7.0",
 ]
 synth = [
     "torch==2.8.0",
@@ -55,7 +55,7 @@ trl = [
     "vllm==0.11.2",
     "codecarbon==3.0.6",
     "wandb==0.21.0",
-    "liger-kernel==0.6.1",
+    "liger-kernel==0.7.0",
 ]
 tests = [
     "torch>=2.0",

--- a/tests/tests_distributed.py
+++ b/tests/tests_distributed.py
@@ -300,6 +300,30 @@ def test_mfu_registry_dense():
     assert "dense_transformer" in MFU_REGISTRY
 
 
+def test_mfu_registry_moe():
+    """'moe' strategy is registered and reuses the dense-transformer formula."""
+    assert "moe" in MFU_REGISTRY
+    assert MFU_REGISTRY["moe"] is MFU_REGISTRY["dense_transformer"]
+
+
+def test_calculate_training_metrics_moe_uses_active_params():
+    """MoE MFU should match the dense formula when given the same num_parameters
+    (which the trainer is expected to populate with the active param count)."""
+    common = dict(
+        peak_flops=300e12,
+        num_parameters=10_000_000,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        head_dim=64,
+        sequence_length=512,
+    )
+    moe_ctx = MFUContext(mfu_type="moe", **common)
+    dense_ctx = MFUContext(mfu_type="dense_transformer", **common)
+    moe_metrics = calculate_training_metrics(moe_ctx, 4, 2, 1, dt=1.0)
+    dense_metrics = calculate_training_metrics(dense_ctx, 4, 2, 1, dt=1.0)
+    assert moe_metrics.mfu == dense_metrics.mfu
+
+
 def test_create_mfu_context():
     """create_mfu_context builds a correct MFUContext from mock args."""
     args = TrainingArguments()
@@ -441,11 +465,27 @@ def test_mamba_layer_macs_formula():
 
 
 def test_attention_layer_macs_formula():
-    """Verify _attention_layer_macs."""
+    """Verify _attention_layer_macs (defaults to MHA when num_key_value_heads is 0)."""
     ctx = _make_mamba_context()
-    d, s = 1536, 1024
-    expected = 4 * d * d + d * s + 3 * d * 512
+    d, s, h, head_dim = 1536, 1024, 12, 128
+    q_dim = h * head_dim
+    # MHA fallback: kv_dim == q_dim, so projections == 2*d*q + 2*d*q == 4*d*q.
+    expected = 2 * d * q_dim + 2 * d * q_dim + d * s + 3 * d * 512
     assert _attention_layer_macs(ctx) == expected
+
+
+def test_attention_layer_macs_gqa():
+    """GQA: K/V projection cost scales with num_key_value_heads."""
+    # 12 query heads, 4 KV heads (Granite-MoE-Hybrid style).
+    ctx = _make_mamba_context(num_attention_heads=12, num_key_value_heads=4)
+    d, s, head_dim = 1536, 1024, 128
+    q_dim = 12 * head_dim
+    kv_dim = 4 * head_dim
+    expected = 2 * d * q_dim + 2 * d * kv_dim + d * s + 3 * d * 512
+    assert _attention_layer_macs(ctx) == expected
+    # GQA must be strictly cheaper than MHA at equal query-head count.
+    mha_ctx = _make_mamba_context(num_attention_heads=12, num_key_value_heads=12)
+    assert _attention_layer_macs(ctx) < _attention_layer_macs(mha_ctx)
 
 
 def test_linear_attention_layer_macs_formula():
@@ -565,10 +605,95 @@ def test_create_mfu_context_mamba_fields():
     assert ctx.linear_num_key_heads == 0
 
 
+def test_mfu_registry_moe_hybrid():
+    """'moe_hybrid' is registered and reuses the mamba/hybrid strategy."""
+    assert "moe_hybrid" in MFU_REGISTRY
+    assert MFU_REGISTRY["moe_hybrid"] is MFU_REGISTRY["hybrid"]
+
+
+def test_active_mlp_macs_dense_vs_moe():
+    """
+    The MLP MAC term should reflect *active* compute when MoE fields are set,
+    and fall back to the dense intermediate_size otherwise.
+    """
+    # Dense fallback: num_experts_per_tok = 0.
+    dense_ctx = _make_mamba_context()
+    d_dense = 1536
+    # _attention_layer_macs MLP term = 3 * d * intermediate_size
+    expected_dense_mlp = 3 * d_dense * 512
+    expected_dense_total = 4 * d_dense * d_dense + d_dense * 1024 + expected_dense_mlp
+    assert _attention_layer_macs(dense_ctx) == expected_dense_total
+
+    # GraniteMoeHybrid-style: routed-MoE + shared expert.
+    moe_ctx = _make_mamba_context(
+        num_experts_per_tok=6,
+        moe_intermediate_size=512,
+        shared_intermediate_size=1024,
+    )
+    expected_moe_mlp = 3 * d_dense * 512 * 6 + 3 * d_dense * 1024
+    expected_moe_total = 4 * d_dense * d_dense + d_dense * 1024 + expected_moe_mlp
+    assert _attention_layer_macs(moe_ctx) == expected_moe_total
+    # Sanity: MoE-active MLP > dense baseline here (top-6 of 64 experts + shared).
+    assert _attention_layer_macs(moe_ctx) > _attention_layer_macs(dense_ctx)
+
+
+def test_moe_hybrid_mfu_granite_like():
+    """End-to-end MFU calculation for a GraniteMoeHybrid-shaped config."""
+    layer_types = tuple(
+        "attention" if i in (5, 15, 25, 35) else "mamba"
+        for i in range(40)
+    )
+    ctx = _make_mamba_context(
+        mfu_type="moe_hybrid",
+        num_hidden_layers=40,
+        layer_types=layer_types,
+        num_experts_per_tok=6,
+        moe_intermediate_size=512,
+        shared_intermediate_size=1024,
+    )
+    metrics = calculate_training_metrics(
+        ctx, micro_batch_size=2, gradient_accumulation_steps=1, world_size=1, dt=1.0,
+    )
+    assert metrics.mfu > 0
+
+    # Same architecture without MoE flags must report a strictly smaller MFU,
+    # because the per-layer MLP term collapses to a single dense MLP.
+    ctx_no_moe = _make_mamba_context(
+        mfu_type="moe_hybrid",
+        num_hidden_layers=40,
+        layer_types=layer_types,
+    )
+    metrics_no_moe = calculate_training_metrics(
+        ctx_no_moe, micro_batch_size=2, gradient_accumulation_steps=1, world_size=1, dt=1.0,
+    )
+    assert metrics.mfu > metrics_no_moe.mfu
+
+
+def test_create_mfu_context_moe_fields():
+    """create_mfu_context extracts MoE fields from args."""
+    args = TrainingArguments()
+    args.mfu_type = "moe_hybrid"
+    args.num_hidden_layers = 40
+    args.num_attention_heads = 12
+    args.head_dim = 128
+    args.max_position_embeddings = 1024
+    args.num_experts_per_tok = 6
+    args.moe_intermediate_size = 512
+    args.shared_intermediate_size = 1024
+
+    ctx = create_mfu_context(args, "a100", num_parameters=0)
+
+    assert ctx.num_experts_per_tok == 6
+    assert ctx.moe_intermediate_size == 512
+    assert ctx.shared_intermediate_size == 1024
+
+
 if __name__ == "__main__":
     for _fn in [
         test_peak_flops_registry,
         test_mfu_registry_dense,
+        test_mfu_registry_moe,
+        test_calculate_training_metrics_moe_uses_active_params,
         test_mfu_registry_hybrid,
         test_create_mfu_context,
         test_create_mfu_context_unsupported_hardware,
@@ -577,11 +702,16 @@ if __name__ == "__main__":
         test_calculate_training_metrics_invalid_type,
         test_mamba_layer_macs_formula,
         test_attention_layer_macs_formula,
+        test_attention_layer_macs_gqa,
         test_linear_attention_layer_macs_formula,
         test_mamba_mfu_pure,
         test_mamba_mfu_hybrid_layer_types,
         test_mamba_mfu_linear_attention_hybrid,
         test_create_mfu_context_mamba_fields,
+        test_mfu_registry_moe_hybrid,
+        test_active_mlp_macs_dense_vs_moe,
+        test_moe_hybrid_mfu_granite_like,
+        test_create_mfu_context_moe_fields,
     ]:
         run_test(_fn.__name__, _fn)
 

--- a/utils/inspect_model.py
+++ b/utils/inspect_model.py
@@ -112,7 +112,7 @@ def inspect_model(
         print(f"\n[2] Tokenizer: Not specified (use --base_model to load)")
     
     # Update config with precision info
-    config.torch_dtype = precision
+    config.dtype = precision
     config.vocab_size = max(config.vocab_size, len(tokenizer) if tokenizer else config.vocab_size)
     
     # Initialize model


### PR DESCRIPTION
- Replace deprecated `torch_dtype` with `dtype`
- Build with `transformers==5.6.2` and `liger-kernel==0.7.0` works in distributed setting
- Add moe and moe_hybrid options for MFU; fix dense model MFU calculation for GPA