### PR TITLE
Consolidate module loading into a single auto-detecting .modules.sh

### DIFF
--- a/.modules.sh
+++ b/.modules.sh
@@ -1,0 +1,63 @@
+# Auto-detecting module loader for the Marvin dual-stack (AMD / Intel).
+#
+# Source this file from any sbatch script:
+#
+#     source "$workdir/.modules.sh"
+#
+# Detection rules (first match wins):
+#   1. $LLM_FOUNDRY_STACK is set explicitly to "amd" or "intel" -> use it.
+#   2. The job requests a GPU via --gres (SLURM_JOB_GRES contains "gpu")   -> AMD.
+#   3. The partition name contains "gpu" (case-insensitive)                -> AMD.
+#   4. Any other SLURM partition                                           -> Intel.
+#   5. No SLURM context                                                    -> Intel (with warning).
+
+_stack=""
+_reason=""
+
+if [[ -n "${LLM_FOUNDRY_STACK:-}" ]]; then
+    _stack="${LLM_FOUNDRY_STACK,,}"
+    _reason="LLM_FOUNDRY_STACK=${LLM_FOUNDRY_STACK}"
+elif [[ -n "${SLURM_JOB_GRES:-}" && "${SLURM_JOB_GRES,,}" == *gpu* ]]; then
+    _stack="amd"
+    _reason="SLURM_JOB_GRES=${SLURM_JOB_GRES} (GPU job -> AMD stack)"
+elif [[ -n "${SLURM_JOB_PARTITION:-}" && "${SLURM_JOB_PARTITION,,}" == *gpu* ]]; then
+    _stack="amd"
+    _reason="SLURM_JOB_PARTITION=${SLURM_JOB_PARTITION} (GPU partition -> AMD stack)"
+elif [[ -n "${SLURM_JOB_PARTITION:-}" ]]; then
+    _stack="intel"
+    _reason="SLURM_JOB_PARTITION=${SLURM_JOB_PARTITION} (CPU partition -> Intel stack)"
+else
+    _stack="intel"
+    _reason="no SLURM context detected; defaulting to Intel stack (set LLM_FOUNDRY_STACK to override)"
+    echo "[.modules.sh] WARNING: ${_reason}" >&2
+fi
+
+echo "[.modules.sh] Stack: ${_stack}  (${_reason})"
+
+case "${_stack}" in
+    amd)
+        # AMD-based installations/operations.
+        export MODULEPATH=/opt/software/easybuild-AMD/modules/all:/etc/modulefiles:/usr/share/modulefiles:/opt/software/modulefiles:/usr/share/modulefiles/Linux:/usr/share/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core
+        module purge
+        module load CUDA/12.6.0 Python/3.12.3-GCCcore-13.3.0
+        ;;
+    intel)
+        # Intel-based installations/operations.
+        module --force purge
+        module load Python/3.12.3-GCCcore-13.3.0
+        ;;
+    *)
+        echo "[.modules.sh] ERROR: unknown stack '${_stack}' (expected 'amd' or 'intel')" >&2
+        unset _stack _reason
+        return 1 2>/dev/null || exit 1
+        ;;
+esac
+
+# Report what's loaded so the job log shows the resolved environment.
+if command -v module >/dev/null 2>&1; then
+    echo "[.modules.sh] Loaded modules:"
+    module list 2>&1 | sed 's/^/    /'
+fi
+
+export LLM_FOUNDRY_STACK="${_stack}"
+unset _stack _reason

--- a/.modules_amd.sh
+++ b/.modules_amd.sh
@@ -1,4 +1,0 @@
-# This file sets up the module environment for AMD-based installations/operations.
-export MODULEPATH=/opt/software/easybuild-AMD/modules/all:/etc/modulefiles:/usr/share/modulefiles:/opt/software/modulefiles:/usr/share/modulefiles/Linux:/usr/share/modulefiles/Core:/usr/share/lmod/lmod/modulefiles/Core
-module purge
-module load CUDA/12.6.0 Python/3.12.3-GCCcore-13.3.0

--- a/.modules_intel.sh
+++ b/.modules_intel.sh
@@ -1,3 +1,0 @@
-# This file sets up the module environment for Intel-based installations/operations.
-module --force purge
-module load Python/3.12.3-GCCcore-13.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,32 @@ LLM Foundry runs on the [Marvin cluster](https://www.hpc.uni-bonn.de/) (Universi
 
 In short:
 
-- The modules for your stack (AMD or Intel) are defined in `.modules_amd.sh` and `.modules_intel.sh`. Source the appropriate one to load the correct environment. You **don't** need to do this on your local machine - only on the cluster.
+- **Create a workspace on the cluster.** Use `utils/marvin_create_workspace.sh` to allocate a workspace, clone the repository, and prepare the directory layout. Open the script first and edit the user customization section at the top (`username`, `file_system`, `work_group`, `email`, `workspace_name`) to match your account, then run it from a Marvin login node:
 
     ```bash
-    # Load the correct modules for your stack (AMD or Intel)
-    source .modules_amd.sh   # or .modules_intel.sh
-
+    bash utils/marvin_create_workspace.sh
     ```
 
-- The installation script `installation.sh` is only for setting up a new workspace on the cluster. If you are developing locally, you can install the dependencies directly with pip (see below). If you're working on the cluster, run the installation script to set up your workspace and install the dependencies:
+    The script also contains commented step-by-step instructions for creating the per-config virtual environments (`.venv_data`, `.venv_distributed`, `.venv_synth`, `.venv_trl`) and submitting the `pip install` jobs to the right partition. You **don't** need any of this on your local machine - only on the cluster.
+
+- **Stack sourcing.** Marvin has a dual software stack (AMD and Intel). The single `.modules.sh` file at the repository root loads the right one for you. It auto-detects the stack from the SLURM environment so most of the time you just source it and forget about it:
 
     ```bash
-    # Run the installation helper
-    bash installation.sh
+    # Inside a SLURM job: auto-detected from #SBATCH directives
+    #   - GPU job (--gres=gpu:...)             -> AMD
+    #   - partition name contains "gpu"        -> AMD
+    #   - any other partition                  -> Intel
+    source "$workdir/.modules.sh"
     ```
+
+    On a login node there is no SLURM context, so you must force the stack explicitly when creating venvs or running ad-hoc commands:
+
+    ```bash
+    LLM_FOUNDRY_STACK=amd   source "$workdir/.modules.sh"   # GPU/training stack
+    LLM_FOUNDRY_STACK=intel source "$workdir/.modules.sh"   # CPU/data stack
+    ```
+
+    Sourcing prints which stack was selected, why, and the resulting `module list`, so your job logs always show the resolved environment.
 
 To install a specific set of dependencies (e.g., for training or data processing), use the extras defined in `pyproject.toml`:
 

--- a/README
+++ b/README
@@ -30,16 +30,16 @@ All of our code base is made to run on the Marvin cluster (University of Bonn).
 Installation
 ------------
 
-You can use the `installation.sh` to help you create workspaces in Marvin. Marvin has a dual stack setup (Intel / AMD), so make sure to create your local environments with this in mind (see `installation.sh` for details).
+You can use the `utils/marvin_create_workspace.sh` to help you create workspaces in Marvin. Marvin has a dual stack setup (Intel / AMD), so make sure to create your local environments with this in mind (see `utils/marvin_create_workspace.sh` for details).
 
-The `.modules_{amd|intel}.sh` file contains all the modules you need to load in order to run our code base in Marvins AMD or Intel stack (see `installation.sh` for details).
+The `.modules.sh` file at the repository root loads the modules needed to run our code base on Marvin. It auto-detects whether you are on the AMD or Intel stack based on the SLURM environment (GPU jobs and partitions whose name contains "gpu" -> AMD; everything else -> Intel). You can also force a stack by exporting `LLM_FOUNDRY_STACK=amd` or `LLM_FOUNDRY_STACK=intel` before sourcing it (useful on a login node when creating `venv` environments).
 
-You can also use the `pyproject.toml` to install certain specific/working builds of our code base. The `pyproject.toml` has currently some basic builds to work with:
+You can use the `pyproject.toml` to install certain specific/working builds of our code base. The `pyproject.toml` has currently some basic builds to work with:
 
 * `data`: For downloading and preprocessing datasets.
-* `distributed`: For training and evaluating language models with DDP and FSDP.
-* `synth`: For generating synthetic datasets with vLLM.
-* `trl`: For training and evaluating language models with TRL.
+* `distributed`: For training language models with our DDP and FSDP implementations.
+* `synth`: For generating synthetic samples with vLLM.
+* `trl`: For post-training and alignment with TRL.
 * `tests`: For running our test suite.
 
 Acknowledgments

--- a/data/cc/process_cc_dump.sh
+++ b/data/cc/process_cc_dump.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/process-common-crawl-err.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 #python3 -m venv $workdir/.venv_intel
 source $workdir/.venv_intel/bin/activate
 

--- a/data/cc/process_cc_dump_all_languages.sh
+++ b/data/cc/process_cc_dump_all_languages.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/process-cc-all-languages-err.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 #python3 -m venv $workdir/.venv_intel
 source $workdir/.venv_intel/bin/activate
 

--- a/data/decontaminate.sh
+++ b/data/decontaminate.sh
@@ -33,7 +33,7 @@ err="$workdir/run_outputs/err-decontaminate.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/data/filters/langdetect_language_filter.sh
+++ b/data/filters/langdetect_language_filter.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-langdetect-filter.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 # pip3 install langdetect --no-cache-dir
 

--- a/data/filters/minhash.sh
+++ b/data/filters/minhash.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-dedup-minhash.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 # pip3 install datatrove[io,processing] --no-cache-dir
 # pip3 install indic-nlp-library --no-cache-dir

--- a/data/filters/quality_filters.sh
+++ b/data/filters/quality_filters.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-quality-filters.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 # pip3 install datatrove[io,processing] --no-cache-dir
 # pip3 install indic-nlp-library --no-cache-dir

--- a/data/filters/run_classifier.sh
+++ b/data/filters/run_classifier.sh
@@ -37,7 +37,7 @@ done
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/data/filters/sft_filters.sh
+++ b/data/filters/sft_filters.sh
@@ -35,7 +35,7 @@ err="$workdir/run_outputs/err-sft-filter.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/data/filters/train_classifier.sh
+++ b/data/filters/train_classifier.sh
@@ -44,7 +44,7 @@ err="$workdir/run_training_outputs/err-train-classifier.$SLURM_JOB_ID"
 # - NCCL Documentation:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/data/filters/train_several_classifiers.sh
+++ b/data/filters/train_several_classifiers.sh
@@ -46,7 +46,7 @@ done
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
 #############################################
 
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/data/filters/unicode_language_filter.sh
+++ b/data/filters/unicode_language_filter.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-unicode-filter.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/distributed/train_ddp.sh
+++ b/distributed/train_ddp.sh
@@ -38,7 +38,7 @@ err="$workdir/run_outputs/err.$SLURM_JOB_ID"
 # Python 3.12, CUDA 12.6, PyTorch 2.8, and CXX11 ABI set to TRUE.
 #############################################
 
-source $workdir/.modules_amd.sh
+source $workdir/.modules.sh
 # python3 -m venv $workdir/.venv_ddp
 source $workdir/.venv_ddp/bin/activate
 

--- a/distributed/train_fsdp.sh
+++ b/distributed/train_fsdp.sh
@@ -38,7 +38,7 @@ err="$workdir/run_outputs/err.$SLURM_JOB_ID"
 # Python 3.12, CUDA 12.6, PyTorch 2.8, and CXX11 ABI set to TRUE.
 #############################################
 
-source $workdir/.modules_amd.sh
+source $workdir/.modules.sh
 # python3 -m venv $workdir/.venv_fsdp
 source $workdir/.venv_fsdp/bin/activate
 

--- a/dpo/alpaca_eval.sh
+++ b/dpo/alpaca_eval.sh
@@ -36,7 +36,7 @@ err="$workdir/run_outputs/err-alpaca.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 # pip3 install alpaca-eval --no-cache-dir
 

--- a/dpo/dpo_trainer.sh
+++ b/dpo/dpo_trainer.sh
@@ -43,7 +43,7 @@ err="$workdir/run_outputs/err-dpo-trainer.$SLURM_JOB_ID"
 # - NCCL Documentation:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 # python3 -m venv $workdir/.venv_trl
 source "$workdir/.venv_trl/bin/activate"
 

--- a/evals/eval_harness_bn.sh
+++ b/evals/eval_harness_bn.sh
@@ -39,7 +39,7 @@ ulimit -c 0                                # <-- Disable core dumps (saves disk 
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh                  # <-- Load required modules (Python, CUDA, etc.)
+source $workdir/.modules.sh                  # <-- Load required modules (Python, CUDA, etc.)
 # python3 -m venv $workdir/.venv_eval_bengali    # <-- UNCOMMENT on first run to create virtual environment
 source $workdir/.venv_eval_bengali/bin/activate  # <-- Activate the virtual environment
 

--- a/evals/eval_harness_hi.sh
+++ b/evals/eval_harness_hi.sh
@@ -39,7 +39,7 @@ ulimit -c 0                                # <-- Disable core dumps (saves disk 
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh                  # <-- Load required modules (Python, CUDA, etc.)
+source $workdir/.modules.sh                  # <-- Load required modules (Python, CUDA, etc.)
 #python3 -m venv $workdir/.venv_eval_hindi       # <-- UNCOMMENT on first run to create virtual environment
 source $workdir/.venv_eval_hindi/bin/activate    # <-- Activate the virtual environment
 

--- a/evals/eval_harness_pt_new.sh
+++ b/evals/eval_harness_pt_new.sh
@@ -39,7 +39,7 @@ ulimit -c 0                                # <-- Disable core dumps (saves disk 
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh            # <-- Load required modules (Python, CUDA, etc.)
+source $workdir/.modules.sh            # <-- Load required modules (Python, CUDA, etc.)
 # python3 -m venv $workdir/.venv_eval_pt   # <-- UNCOMMENT on first run to create virtual environment
 source $workdir/.venv_eval_pt/bin/activate  # <-- Activate the virtual environment
 

--- a/evals/eval_harness_pt_old.sh
+++ b/evals/eval_harness_pt_old.sh
@@ -39,7 +39,7 @@ ulimit -c 0                                # <-- Disable core dumps (saves disk 
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh                  # <-- Load required modules (Python, CUDA, etc.)
+source $workdir/.modules.sh                  # <-- Load required modules (Python, CUDA, etc.)
 # python3 -m venv $workdir/.venv_eval_pt_old     # <-- UNCOMMENT on first run to create virtual environment
 source $workdir/.venv_eval_pt_old/bin/activate   # <-- Activate the virtual environment
 

--- a/hf_hub/convert_to_hf.sh
+++ b/hf_hub/convert_to_hf.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-convert-local-to-hf.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 
 export HF_DATASETS_CACHE="$workdir/.cache/$SLURM_JOB_ID"

--- a/hf_hub/download_repository.sh
+++ b/hf_hub/download_repository.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-download-hf.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/hf_hub/save_as.sh
+++ b/hf_hub/save_as.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-save-as.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/hf_hub/upload_ckpts_to_hf.sh
+++ b/hf_hub/upload_ckpts_to_hf.sh
@@ -33,7 +33,7 @@ err="$workdir/run_outputs/err-hf-upload-ckpts.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/hf_hub/upload_repository.sh
+++ b/hf_hub/upload_repository.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-hf-upload.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/long_ctx/filter_long_context_dataset.sh
+++ b/long_ctx/filter_long_context_dataset.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-filter-long-context.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/long_ctx/generate_continuation.sh
+++ b/long_ctx/generate_continuation.sh
@@ -36,7 +36,7 @@ err="$workdir/run_outputs/err-gen.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/long_ctx/train_hf.sh
+++ b/long_ctx/train_hf.sh
@@ -29,7 +29,7 @@ mkdir -p "$workdir/run_outputs"
 cd "$workdir"
 ulimit -c 0
 
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 #pip3 install trl --no-cache-dir
 #pip3 install vllm==0.11.2 --no-cache-dir

--- a/merge/merge.sh
+++ b/merge/merge.sh
@@ -33,7 +33,7 @@ err="$workdir/run_outputs/err_merge.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 # python3 -m venv $workdir/.venv_intel_merge
 source $workdir/.venv_intel_merge/bin/activate
 

--- a/merge/tokensurgeon.sh
+++ b/merge/tokensurgeon.sh
@@ -33,7 +33,7 @@ err="$workdir/run_outputs/err-tokensurgeon.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 # python3 -m venv $workdir/.venv_intel_merge
 source $workdir/.venv_intel_merge/bin/activate
 

--- a/sft/inference_test.sh
+++ b/sft/inference_test.sh
@@ -33,7 +33,7 @@ err="$workdir/run_outputs/err-inference.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_amd/bin/activate"
 pip3 install json-repair --no-cache-dir
 

--- a/sft/sft_trainer.sh
+++ b/sft/sft_trainer.sh
@@ -43,7 +43,7 @@ err="$workdir/run_outputs/err-sft-trainer.$SLURM_JOB_ID"
 # - NCCL Documentation:
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 # python3 -m venv $workdir/.venv_trl
 source "$workdir/.venv_trl/bin/activate"
 

--- a/synthetic/generate.sh
+++ b/synthetic/generate.sh
@@ -37,7 +37,7 @@ done
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh                       # <-- Load necessary modules
+source $workdir/.modules.sh                       # <-- Load necessary modules
 # python3 -m venv $workdir/.venv_synth                # <-- Create virtual environment
 source $workdir/.venv_synth/bin/activate              # <-- Activate virtual environment
 

--- a/synthetic/generate_cai.sh
+++ b/synthetic/generate_cai.sh
@@ -35,7 +35,7 @@ err="$workdir/synth/logs/err-synthetic-cai.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh
+source $workdir/.modules.sh
 # python3 -m venv $workdir/.venv_synth  
 source $workdir/.venv_synth/bin/activate
 

--- a/synthetic/generate_datatrove.sh
+++ b/synthetic/generate_datatrove.sh
@@ -35,7 +35,7 @@ err="$workdir/synth/.logs/err.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_amd.sh                      # <-- Load necessary modules
+source $workdir/.modules.sh                      # <-- Load necessary modules
 # python3 -m venv "$workdir/.venv_synth"             # <-- Create a clean virtual environment
 source "$workdir/.venv_synth/bin/activate"           # <-- Activate virtual environment
 

--- a/tests/README
+++ b/tests/README
@@ -29,8 +29,12 @@ Or run a single script directly:
     python tests/tests_synthetic.py
 
 
+To run tests regarding the module loading logic on Marvin's dual stack (Intel|AMD CPU and NVIDIA GPU), use the following scripts:
+
+    bash tests/test_modules_cpu.sh
+    bash tests/test_modules_gpu.sh
+
 Notes
 -----
 
 * All test scripts set `sys.pycache_prefix` to `tmp/pycache` in the Linux temp directory (via `tempfile.gettempdir()`).
-

--- a/tests/test_modules_cpu.sh
+++ b/tests/test_modules_cpu.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+
+#############################################
+# DUMMY TEST SCRIPT (CPU / Intel stack)
+#############################################
+# This script is NOT meant to be submitted with sbatch -- it just runs
+# locally and FAKES the SLURM environment variables that .modules.sh
+# inspects, so we can verify the auto-detection picks the Intel stack.
+#
+# Run it with:
+#     bash tests/test_modules_cpu.sh
+#############################################
+
+#SBATCH --account=ag_bit_flek
+#SBATCH --partition=lm_medium
+#SBATCH --job-name=test-modules-cpu
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=96
+#SBATCH --time=00:05:00
+#SBATCH --mem=1900G
+#SBATCH --exclusive
+
+#############################################
+# Fake the SLURM environment that sbatch would normally inject.
+# These mirror the #SBATCH directives above. Note: no --gres, so
+# SLURM_JOB_GRES is left unset (CPU-only job).
+#############################################
+export SLURM_JOB_PARTITION="lm_medium"
+unset SLURM_JOB_GRES
+
+# Make sure no previous run leaked an override into our shell.
+unset LLM_FOUNDRY_STACK
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "================================================================"
+echo " DUMMY TEST: CPU partition, no --gres  -->  expect Intel stack"
+echo "================================================================"
+echo "SLURM_JOB_PARTITION = ${SLURM_JOB_PARTITION}"
+echo "SLURM_JOB_GRES      = ${SLURM_JOB_GRES:-<unset>}"
+echo "----------------------------------------------------------------"
+
+source "$repo_root/.modules.sh"
+
+echo "----------------------------------------------------------------"
+echo "Resolved LLM_FOUNDRY_STACK = ${LLM_FOUNDRY_STACK}"
+if [[ "${LLM_FOUNDRY_STACK}" == "intel" ]]; then
+    echo "RESULT: PASS"
+else
+    echo "RESULT: FAIL (expected 'intel', got '${LLM_FOUNDRY_STACK}')"
+fi

--- a/tests/test_modules_gpu.sh
+++ b/tests/test_modules_gpu.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -l
+
+#############################################
+# DUMMY TEST SCRIPT (GPU / AMD stack)
+#############################################
+# This script is NOT meant to be submitted with sbatch -- it just runs
+# locally and FAKES the SLURM environment variables that .modules.sh
+# inspects, so we can verify the auto-detection picks the AMD stack.
+#
+# Run it with:
+#     bash tests/test_modules_gpu.sh
+#############################################
+
+#SBATCH --account=ag_bit_flek
+#SBATCH --partition=sgpu_long
+#SBATCH --job-name=test-modules-gpu
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=32
+#SBATCH --time=00:05:00
+#SBATCH --gres=gpu:a100:4
+#SBATCH --exclusive
+
+#############################################
+# Fake the SLURM environment that sbatch would normally inject.
+# These mirror the #SBATCH directives above.
+#############################################
+export SLURM_JOB_PARTITION="sgpu_long"
+export SLURM_JOB_GRES="gpu:a100:4"
+
+# Make sure no previous run leaked an override into our shell.
+unset LLM_FOUNDRY_STACK
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "================================================================"
+echo " DUMMY TEST: GPU partition + --gres=gpu  -->  expect AMD stack"
+echo "================================================================"
+echo "SLURM_JOB_PARTITION = ${SLURM_JOB_PARTITION}"
+echo "SLURM_JOB_GRES      = ${SLURM_JOB_GRES}"
+echo "----------------------------------------------------------------"
+
+source "$repo_root/.modules.sh"
+
+echo "----------------------------------------------------------------"
+echo "Resolved LLM_FOUNDRY_STACK = ${LLM_FOUNDRY_STACK}"
+if [[ "${LLM_FOUNDRY_STACK}" == "amd" ]]; then
+    echo "RESULT: PASS"
+else
+    echo "RESULT: FAIL (expected 'amd', got '${LLM_FOUNDRY_STACK}')"
+fi

--- a/tokenization/make_validation_split.sh
+++ b/tokenization/make_validation_split.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-make-val-split.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/tokenization/shuffle.sh
+++ b/tokenization/shuffle.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-shuffle.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK

--- a/tokenization/tokenize_dataset_fim.sh
+++ b/tokenization/tokenize_dataset_fim.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-tok-fim.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/tokenization/tokenize_dataset_pt.sh
+++ b/tokenization/tokenize_dataset_pt.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-tok-pt.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/tokenization/tokenize_dataset_sft.sh
+++ b/tokenization/tokenize_dataset_sft.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-tok-instruct.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your HF token

--- a/tokenization/tokenizer_eval.sh
+++ b/tokenization/tokenizer_eval.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-tok-eval.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source $workdir/.modules_intel.sh
+source $workdir/.modules.sh
 source $workdir/.venv_intel/bin/activate
 
 export HF_TOKEN="<your-token-here>" # <-- Change to your Hugging Face token

--- a/tokenization/train_tokenizer_sentencepiece.sh
+++ b/tokenization/train_tokenizer_sentencepiece.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-train-sp-tok.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 # pip3 install sentencepiece==0.2.0 transformers --no-cache-dir
 

--- a/tokenization/train_tokenizer_tokenizers.sh
+++ b/tokenization/train_tokenizer_tokenizers.sh
@@ -34,7 +34,7 @@ err="$workdir/run_outputs/err-train-hf-tok.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_intel.sh"
+source "$workdir/.modules.sh"
 source "$workdir/.venv_intel/bin/activate"
 # pip3 install sentencepiece==0.2.0 transformers --no-cache-dir
 

--- a/utils/README
+++ b/utils/README
@@ -9,6 +9,7 @@ Contents
 --------
 
 * inspect_model.py: Analyze model configurations and compute parameter counts (including MoE expert routing).
+* marvin_create_workspace.sh: A helper script to create a new workspace in the Marvin cluster.
 * pdf2markdown.sh: Convert PDF documents to Markdown format using Marker.
 * parse_run.py: Parse and summarize training run logs for the distributed training scripts.
 

--- a/utils/marvin_create_workspace.sh
+++ b/utils/marvin_create_workspace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 #############################################
-# Workspace Setup Script for HPC Usage
+# Workspace Setup Script for Marvin HPC Cluster
 #############################################
 # This script allocates a workspace on the Marvin HPC cluster,
 # clones the repository, and prepares the directory structure.
@@ -18,6 +18,8 @@ email="kluge@uni-bonn.de"      # <-- Change to your email
 remainder=7                    # <-- Change as needed
 num_days=90                    # <-- Change as needed
 workspace_name="polyglot"      # <-- Change to your workspace/project name
+
+# Workspace directory (constructed from the above variables)
 workdir="/lustre/$file_system/data/$username-$workspace_name"
 
 #############################################
@@ -41,6 +43,36 @@ git clone --branch main https://github.com/Polygl0t/llm-foundry.git
 echo "Workspace ready."
 
 #############################################
+# Stack Sourcing (.modules.sh)
+#############################################
+# Marvin has a dual software stack (AMD and Intel). Instead of two
+# separate module files, this repo ships a single auto-detecting
+# loader at the repository root: `.modules.sh`.
+#
+# How it picks a stack (first match wins):
+#
+#   1. $LLM_FOUNDRY_STACK is set to "amd" or "intel"   -> use it
+#   2. SLURM_JOB_GRES contains "gpu"  (--gres=gpu:...) -> AMD
+#   3. SLURM_JOB_PARTITION contains "gpu"              -> AMD
+#   4. Any other SLURM partition                       -> Intel
+#   5. No SLURM context (e.g. login node)              -> Intel + warning
+#
+# Inside a SLURM job, sbatch sets SLURM_JOB_GRES / SLURM_JOB_PARTITION
+# automatically from your #SBATCH directives, so the right stack is
+# selected without any extra configuration:
+#
+#   source $workdir/.modules.sh
+#
+# On a login node (no SLURM context) you must force the stack when
+# creating venvs or running interactive commands:
+#
+#   LLM_FOUNDRY_STACK=amd   source $workdir/.modules.sh
+#   LLM_FOUNDRY_STACK=intel source $workdir/.modules.sh
+#
+# When sourced, the script logs the chosen stack, the reason, and a
+# `module list` so the resolved environment is visible in your job log.
+
+#############################################
 # Installing Dependencies
 #############################################
 # Dependencies are managed via pyproject.toml with optional groups:
@@ -50,20 +82,24 @@ echo "Workspace ready."
 #   synth        - Synthetic data generation (torch, vllm, etc.)
 #   trl          - Fine-tuning with TRL (trl, vllm, flash_attn, etc.)
 #
-# Marvin uses a dual software stack (AMD and Intel). Each config
-# needs the correct modules and must be installed on the matching
-# node type so that hardware-specific packages resolve correctly.
+# Each config must be installed on the matching node type so that
+# hardware-specific packages (CUDA wheels, flash-attn, etc.) resolve
+# correctly. The `.modules.sh` loader handles stack selection for you;
+# you just need to submit the install job to the correct partition.
 #
-#   Config        Modules file         SLURM partition (recommended)
-#   ------        ------------         ---------------
-#   data          .modules_intel.sh    lm_short (Intel nodes)
-#   distributed   .modules_amd.sh     mlgpu_short (AMD/GPU nodes)
-#   synth         .modules_amd.sh     mlgpu_short (AMD/GPU nodes)
-#   trl           .modules_amd.sh     mlgpu_short (AMD/GPU nodes)
+#   Config        Stack       SLURM partition (recommended)
+#   ------        -----       ---------------
+#   data          intel       lm_short (Intel nodes)
+#   distributed   amd         mlgpu_short (AMD/GPU nodes)
+#   synth         amd         mlgpu_short (AMD/GPU nodes)
+#   trl           amd         mlgpu_short (AMD/GPU nodes)
 #
 # --- Step 1: Create a virtual environment (on the login node) ---
 #
-#   source $workdir/.modules_amd.sh          # or .modules_intel.sh for "data"
+# On the login node there is no SLURM context, so force the stack
+# explicitly via LLM_FOUNDRY_STACK before creating the venv:
+#
+#   LLM_FOUNDRY_STACK=amd source $workdir/.modules.sh   # or =intel for "data"
 #   python3 -m venv $workdir/.venv_<config>
 #   source $workdir/.venv_<config>/bin/activate
 #   pip install --upgrade pip
@@ -71,6 +107,10 @@ echo "Workspace ready."
 #   module purge
 #
 # --- Step 2: Install packages (as a SLURM job on the correct node) ---
+#
+# Inside the job, sbatch has set SLURM_JOB_GRES / SLURM_JOB_PARTITION
+# from your #SBATCH directives, so `.modules.sh` resolves the stack
+# automatically -- no LLM_FOUNDRY_STACK override needed.
 #
 #   sbatch --export=ALL <<'EOF'
 #   #!/bin/bash -l
@@ -86,14 +126,14 @@ echo "Workspace ready."
 #   #SBATCH --gres=gpu:a40:1               # We only need a GPU for the "distributed", "synth", and "trl" configs to resolve hardware-specific packages. Omit for "data".
 #   #SBATCH --oversubscribe
 #
-#   source $workdir/.modules_amd.sh        # or .modules_intel.sh
+#   source $workdir/.modules.sh        # auto-detects the stack inside the job
 #   source $workdir/.venv_<config>/bin/activate
 #   pip install -e /path/to/llm-foundry/.[<config>]
 #   EOF
 #
 # Example — installing the "distributed" config:
 #
-#   source $workdir/.modules_amd.sh
+#   LLM_FOUNDRY_STACK=amd source $workdir/.modules.sh
 #   python3 -m venv $workdir/.venv_distributed
 #   source $workdir/.venv_distributed/bin/activate
 #   pip install --upgrade pip
@@ -114,7 +154,7 @@ echo "Workspace ready."
 #   #SBATCH --gres=gpu:a40:1
 #   #SBATCH --oversubscribe
 #
-#   source /lustre/mlnvme/data/nklugeco_hpc-polyglot/.modules_amd.sh
+#   source /lustre/mlnvme/data/nklugeco_hpc-polyglot/.modules.sh
 #   source /lustre/mlnvme/data/nklugeco_hpc-polyglot/.venv_distributed/bin/activate
 #   pip install -e /lustre/mlnvme/data/nklugeco_hpc-polyglot/llm-foundry/.[distributed]
 #   pip install flash_attn==2.8.2 --no-build-isolation --no-cache-dir

--- a/utils/pdf2markdown.sh
+++ b/utils/pdf2markdown.sh
@@ -60,7 +60,7 @@ err="$workdir/run_outputs/err-pdf-to-markdown.$SLURM_JOB_ID"
 #############################################
 # Environment Setup
 #############################################
-source "$workdir/.modules_amd.sh"
+source "$workdir/.modules.sh"
 # python3 -m venv "$workdir/.venv_amd_pdf"
 source "$workdir/.venv_amd_pdf/bin/activate"
 # pip3 install marker-pdf --no-cache-dir


### PR DESCRIPTION
Replace .modules_amd.sh and .modules_intel.sh with one .modules.sh at the repo root that selects the stack from the SLURM environment:

  - SLURM_JOB_GRES contains "gpu"             -> AMD
  - SLURM_JOB_PARTITION contains "gpu"   -> AMD
  - any other partition                                       -> Intel
  - LLM_FOUNDRY_STACK=amd|intel            -> manual override (login nodes)

The loader logs the chosen stack, the reason, and the resulting `module list`, so job logs always show the resolved environment.

Add two non-submitting bash test scripts under tests/ that fake the SLURM env vars to verify the detection logic without burning queue time:

  - tests/test_modules_gpu.sh  (sgpu_long + --gres=gpu:a100:4 -> AMD)
  - tests/test_modules_cpu.sh  (lm_medium, no --gres -> Intel)

Update README, CONTRIBUTING.md, and utils/marvin_create_workspace.sh to document the single-file workflow: workspace creation steps, the in-job vs login-node sourcing patterns, and the LLM_FOUNDRY_STACK override.