### PR TITLE
Add --allow_patterns arg to download_repository 

### DIFF
--- a/hf_hub/download_repository.py
+++ b/hf_hub/download_repository.py
@@ -10,7 +10,8 @@ Usage:
         --output_dir /path/to/output \
         --token YOUR_HF_TOKEN \
         --repo_type dataset \
-        --cache_dir ./.cache
+        --cache_dir ./.cache \
+        --allow_patterns "*"
 """
 from huggingface_hub import snapshot_download
 import os
@@ -25,6 +26,8 @@ def main():
     parser.add_argument("--token", required=True, help="Hugging Face token for authentication")
     parser.add_argument("--repo_type", default="dataset", choices=["dataset", "model", "space"],
                        help="Type of repository to download")
+    parser.add_argument("--allow_patterns", nargs="+", default=["*"],
+                       help="Optional glob patterns to filter files to download (e.g., 'de/*' '*.md')")
     
     args = parser.parse_args()
     
@@ -37,6 +40,7 @@ def main():
         token=args.token,
         local_dir_use_symlinks=False,
         local_dir=args.output_dir,
+        allow_patterns=args.allow_patterns
     )
 
 if __name__ == "__main__":

--- a/hf_hub/download_repository.sh
+++ b/hf_hub/download_repository.sh
@@ -59,6 +59,7 @@ python3 "$workdir/download_repository.py" \
     --cache_dir "$HF_DATASETS_CACHE" \
     --token "$HF_TOKEN" \
     --repo_type "dataset" 1>>"$out" 2>>"$err"
+# Optional: add --allow_patterns "de/*" "*.md" or different patterns to filter which files are downloaded
 
 #############################################
 # End of Script


### PR DESCRIPTION
Adds an optional --allow_patterns argument to download_repository.py, which is passed directly to snapshot_download. This allows selectively downloading only files matching one or more glob patterns instead of the entire repository.

Useful when only a language-specific subset of a dataset is needed (e.g., "de/*"), avoiding unnecessary transfer of large files on the cluster.

Defaults to ["*"] (download everything), so existing usage is unaffected.