### PR TITLE
refactor: extract shared dataset loading logic into utils.py

### DIFF
--- a/data/filters/langdetect_language_filter.py
+++ b/data/filters/langdetect_language_filter.py
@@ -15,28 +15,22 @@ Output:
 
 Usage:
     # Filter for single language
-    python langdetect_language_filter.py --input_dir data/ --output_dir filtered/ \\
+    python langdetect_language_filter.py --input_dir data/ --output_dir filtered/ \
         --languages portuguese
     
     # Filter for multiple languages
-    python langdetect_language_filter.py --input_dir data/ --output_dir filtered/ \\
+    python langdetect_language_filter.py --input_dir data/ --output_dir filtered/ \
         --languages english portuguese spanish --num_proc 16
     
     # Save excluded samples for testing
-    python langdetect_language_filter.py --input_dir data/ --output_dir excluded/ \\
+    python langdetect_language_filter.py --input_dir data/ --output_dir excluded/ \
         --languages english --save_excluded
 """
-import datasets
 import argparse
 import glob
-import os
-import numpy as np
 from langdetect import detect, LangDetectException
+from utils import DatasetLoader, save_dataset, is_messages_column, flatten_messages
 
-# TODO: We should stop using print statements and instead use a proper logger.
-# See `data/tokenization/utils.py` for an example of how to set up logging.
-
-# Language code mapping (langdetect uses ISO 639-1 codes)
 LANGUAGE_CODES = {
     'english': 'en',
     'portuguese': 'pt',
@@ -59,13 +53,6 @@ LANGUAGE_CODES = {
 }
 
 def create_language_filter(languages):
-    """
-    Create a filter function to detect specified languages using langdetect.
-    
-    Args:
-        languages: List of language names from LANGUAGE_CODES
-    """
-    # Convert language names to codes
     target_codes = set()
     for lang in languages:
         if lang.lower() in LANGUAGE_CODES:
@@ -79,144 +66,62 @@ def create_language_filter(languages):
     print(f"[INFO] Target language codes: {sorted(target_codes)}")
     
     def filter_language(text):
-        """Check if text is in one of the target languages."""
-        if not text or len(text.strip()) < 10:  # Skip very short texts
+        if not text or len(text.strip()) < 10:
             return False
-        
         try:
             detected_lang = detect(text)
             return detected_lang in target_codes
         except LangDetectException:
-            # If language detection fails, exclude the sample
             return False
     
     return filter_language
 
 
-# TODO: This is also used in `unicode_language_filter.py`. The best solution is to 
-# make these utility functions available in a shared utils file.
-def is_messages_column(dataset, column_name):
-    """
-    Check if a column contains messages in the expected format.
-    
-    Args:
-        dataset: The dataset to check
-        column_name: Name of the column to check
-    
-    Returns:
-        bool: True if the column appears to be a messages column
-    """
-    if column_name not in dataset.column_names:
-        return False
-    
-    # Check the first non-null entry
-    for example in dataset:
-        value = example.get(column_name)
-        if value is None:
-            continue
-        
-        # Check if it's a list of dicts with 'content' key
-        if isinstance(value, list) and len(value) > 0:
-            if isinstance(value[0], dict) and 'content' in value[0]:
-                return True
-        break
-    
-    return False
-
-# TODO: This is also used in `unicode_language_filter.py`. The best solution is to 
-# make these utility functions available in a shared utils file.
-def flatten_messages(messages):
-    """
-    Flatten a messages list into a single text string.
-    
-    Args:
-        messages: List of message dictionaries with 'content' field
-    
-    Returns:
-        str: Flattened text with messages separated by newlines
-    """
-    if not messages:
-        return ""
-    
-    contents = []
-    for msg in messages:
-        if isinstance(msg, dict) and 'content' in msg:
-            content = msg['content']
-            if content:  # Only add non-empty content
-                contents.append(str(content))
-    
-    return '\n'.join(contents)
-
-
 def main(args):
-    # TODO: Create a unified loader that can handle both JSONL and Parquet, and HF Datasets.
-    # We already have a working example in `synthetic/utils.py` and `data/tokenization/utils.py`.
-    assert args.input_type in ["jsonl", "parquet"], "Dataset type must be either 'jsonl' or 'parquet'."
     assert args.output_type in ["jsonl", "parquet"], "Output type must be either 'jsonl' or 'parquet'."
-    
-    # Load dataset
+
+    loader = DatasetLoader(path=args.input_dir, cache_dir=args.cache_dir)
+    dataset = loader.load()
     data_files = glob.glob(f"{args.input_dir}/*.{args.input_type}")
-    if not data_files:
-        raise ValueError(f"No {args.input_type.upper()} files found in '{args.input_dir}'.")
-    
-    dataset = datasets.load_dataset(
-        "json" if args.input_type == "jsonl" else "parquet",
-        data_files=data_files,
-        split="train",
-        cache_dir=args.cache_dir,
-        num_proc=len(data_files),
-    )
-    print(f"[INFO] Loaded dataset with {len(dataset):,} examples from {args.input_type.upper()} files.")
-    print(f"[INFO] Columns: {dataset.column_names}")
-    
-    # Verify text column exists
+
     if args.text_column not in dataset.column_names:
         raise ValueError(f"Column '{args.text_column}' not found in dataset. Available columns: {dataset.column_names}")
-    
-    # Check if the column is a messages column
+
     is_messages = is_messages_column(dataset, args.text_column)
     if is_messages:
         print(f"[INFO] Detected messages format in column '{args.text_column}'")
         print("[INFO] Messages will be flattened before filtering")
-    
-    # Calculate initial token count if column exists
+
     original_count = len(dataset)
     if 'token_count' in dataset.column_names:
         original_tokens = sum(dataset['token_count'])
         print(f"[INFO] Original tokens: {original_tokens:,}")
-    
-    # Filter out non-matching language samples
+
     if args.save_excluded:
         print(f"\n[INFO] Saving EXCLUDED samples (those NOT matching: {', '.join(args.languages)})")
     else:
         print(f"\n[INFO] Filtering samples using langdetect for: {', '.join(args.languages)}")
     language_filter = create_language_filter(args.languages)
-    
-    # Create a modified filter that works with the specified text column
+
     def filter_with_column(example):
         value = example[args.text_column]
-        
-        # Handle messages column
         if is_messages:
             text = flatten_messages(value)
         else:
             text = value
-        
         result = language_filter(text)
-        # Invert the filter if we want to save excluded samples
         return not result if args.save_excluded else result
-    
+
     filtered_dataset = dataset.filter(
         filter_with_column,
         num_proc=args.num_proc or 1,
         desc="Filtering by language",
     )
-    
-    # Calculate statistics
+
     filtered_count = len(filtered_dataset)
     removed_count = original_count - filtered_count
     removed_percentage = (removed_count / original_count * 100) if original_count > 0 else 0
-    
+
     print(f"\n[INFO] ===== FILTERING RESULTS =====")
     print(f"[INFO] Original samples: {original_count:,}")
     if args.save_excluded:
@@ -225,7 +130,7 @@ def main(args):
     else:
         print(f"[INFO] Filtered samples: {filtered_count:,}")
         print(f"[INFO] Removed samples: {removed_count:,} ({removed_percentage:.2f}%)")
-    
+
     if 'token_count' in filtered_dataset.column_names:
         filtered_tokens = sum(filtered_dataset['token_count'])
         removed_tokens = original_tokens - filtered_tokens
@@ -233,46 +138,13 @@ def main(args):
         print(f"[INFO] Original tokens: {original_tokens:,}")
         print(f"[INFO] Filtered tokens: {filtered_tokens:,}")
         print(f"[INFO] Removed tokens: {removed_tokens:,} ({removed_tokens_percentage:.2f}%)")
-    
+
     if filtered_count == 0:
         print("[WARNING] No samples remaining after filtering. Not saving dataset.")
         return
-    
-    # Create output directory
-    os.makedirs(args.output_dir, exist_ok=True)
 
-    # TODO: Chunking and saving logic is duplicated from `unicode_language_filter.py`. 
-    # We should unify this in a shared utility function.
-    # See `data/tokenization/utils.py` for an example of how to implement this in a reusable way.
-    
-    # Determine number of chunks (equal to number of input files)
-    n_chunks = len(data_files)
-    print(f"\n[INFO] Splitting dataset into {n_chunks} chunks (matching input file count)")
-    
-    # Split dataset into chunks
-    indices = np.array_split(np.arange(filtered_count), n_chunks)
-    chunks = [filtered_dataset.select(idx.tolist()) for idx in indices if len(idx) > 0]
-    
-    # Save chunks
-    extension = args.output_type if args.output_type == "parquet" else "jsonl"
-    save_fn = lambda chunk, path: (
-        chunk.to_parquet(path) if args.output_type == "parquet" else chunk.to_json(path)
-    )
-    
-    for i, chunk in enumerate(chunks):
-        filename = f"{args.output_dir}/train-{i:05d}-of-{n_chunks:05d}.{extension}"
-        save_fn(chunk, filename)
-        print(f"[INFO] Saved chunk {i+1}/{n_chunks} with {len(chunk):,} examples to {filename}")
-    
-    # Save metadata
-    with open(f"{args.output_dir}/.metadata", "w") as meta_file:
-        meta_file.write(f"Number of samples: {filtered_count}\n")
-        if 'token_count' in filtered_dataset.column_names:
-            meta_file.write(f"Number of tokens: {filtered_tokens}\n")
-        meta_file.write(f"Chunks: {n_chunks}\n")
-        meta_file.write(f"Columns: {filtered_dataset.column_names}\n")
-    
-    print("\n[INFO] Metadata saved to .metadata file")
+    filtered_tokens = sum(filtered_dataset['token_count']) if 'token_count' in filtered_dataset.column_names else 0
+    save_dataset(filtered_dataset, args.output_dir, args.output_type, tokens_per_chunk=1_000_000, token_count=filtered_tokens, n_chunks=len(data_files))
     print("\n[INFO] Language filtering complete!")
 
 
@@ -281,20 +153,18 @@ if __name__ == "__main__":
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    
-    parser.add_argument("--input_dir", type=str, required=True, help="Directory containing the input dataset files")
-    parser.add_argument("--output_dir", type=str, required=True, help="Output directory to save filtered dataset")
-    parser.add_argument("--languages", type=str, nargs='+', required=True, 
-                        help=f"Languages to keep (space-separated). Available: {', '.join(sorted(LANGUAGE_CODES.keys()))}")
-    parser.add_argument("--input_type", choices=["jsonl", "parquet"], default="parquet", help="Type of the input files")
-    parser.add_argument("--output_type", choices=["jsonl", "parquet"], default="parquet", help="Type of the output files")
-    parser.add_argument("--text_column", type=str, default="text", help="Name of the text column in the dataset")
-    parser.add_argument("--cache_dir", type=str, help="Cache directory for dataset loading")
-    parser.add_argument("--num_proc", type=int, default=8, help="Number of processes to use")
-    parser.add_argument("--save_excluded", action="store_true", help="Save excluded samples instead of included ones (for testing)")
-    
+    parser.add_argument("--input_dir", type=str, required=True)
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--languages", type=str, nargs='+', required=True,
+                        help=f"Languages to keep. Available: {', '.join(sorted(LANGUAGE_CODES.keys()))}")
+    parser.add_argument("--input_type", choices=["jsonl", "parquet"], default="parquet")
+    parser.add_argument("--output_type", choices=["jsonl", "parquet"], default="parquet")
+    parser.add_argument("--text_column", type=str, default="text")
+    parser.add_argument("--cache_dir", type=str)
+    parser.add_argument("--num_proc", type=int, default=8)
+    parser.add_argument("--save_excluded", action="store_true")
+
     args = parser.parse_args()
-    
     print(f"Filtering dataset for {', '.join(args.languages)} text using langdetect...")
     main(args)
     print("Done! 🎆")

--- a/data/filters/unicode_language_filter.py
+++ b/data/filters/unicode_language_filter.py
@@ -4,95 +4,67 @@ Unicode-based Language Filtering
 Filters datasets by character set validation using Unicode ranges for 18+ languages.
 Complementary to langdetect_language_filter.py - useful when language detection fails.
 
-Supported languages:
-English, Portuguese, Spanish, French, German, Italian (Latin scripts)
-Russian, Ukrainian (Cyrillic)
-Arabic, Hebrew (RTL scripts)
-Greek, Hindi, Bengali, Thai, Vietnamese
-Chinese (CJK), Japanese (Hiragana + Katakana + Kanji), Korean (Hangul)
-
-Output:
-- Filtered dataset split into chunks matching input file count
-- .metadata: Document/token counts and statistics
-- Optional excluded samples for debugging
-
 Usage:
     # Filter for Portuguese only
-    python unicode_language_filter.py --input_dir data/ --output_dir filtered/ \\
+    python unicode_language_filter.py --input_dir data/ --output_dir filtered/ \
         --languages portuguese --text_column text
     
     # Multi-language (Latin scripts)
-    python unicode_language_filter.py --input_dir data/ --output_dir filtered/ \\
+    python unicode_language_filter.py --input_dir data/ --output_dir filtered/ \
         --languages english portuguese spanish french --num_proc 16
     
     # Save excluded samples for debugging
-    python unicode_language_filter.py --input_dir data/ --output_dir excluded/ \\
+    python unicode_language_filter.py --input_dir data/ --output_dir excluded/ \
         --languages english --save_excluded
 """
-import datasets
 import argparse
-import glob
-import os
 import re
-import numpy as np
+import glob
+from utils import DatasetLoader, save_dataset, is_messages_column, flatten_messages
 
-# TODO: We should stop using print statements and instead use a proper logger.
-# See `data/tokenization/utils.py` for an example of how to set up logging.
-
-# Language to Unicode range mapping
 LANGUAGE_RANGES = {
-    'english': r'\u0041-\u005A\u0061-\u007A',  # A-Z, a-z
-    'portuguese': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',  # English + Latin Extended
-    'spanish': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',  # English + Latin Extended
-    'french': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',  # English + Latin Extended
-    'german': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',  # English + Latin Extended
-    'italian': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',  # English + Latin Extended
-    'russian': r'\u0400-\u04FF',  # Cyrillic
-    'ukrainian': r'\u0400-\u04FF',  # Cyrillic
-    'arabic': r'\u0600-\u06FF',  # Arabic
-    'greek': r'\u0370-\u03FF',  # Greek
-    'hebrew': r'\u0590-\u05FF',  # Hebrew
-    'hindi': r'\u0900-\u097F',  # Devanagari
-    'bengali': r'\u0980-\u09FF',  # Bengali
-    'chinese': r'\u4E00-\u9FFF',  # CJK Unified Ideographs
-    'japanese': r'\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF',  # Hiragana + Katakana + Kanji
-    'korean': r'\uAC00-\uD7AF',  # Hangul
-    'thai': r'\u0E00-\u0E7F',  # Thai
-    'vietnamese': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF\u0100-\u017F',  # Latin + Extensions
+    'english': r'\u0041-\u005A\u0061-\u007A',
+    'portuguese': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',
+    'spanish': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',
+    'french': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',
+    'german': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',
+    'italian': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF',
+    'russian': r'\u0400-\u04FF',
+    'ukrainian': r'\u0400-\u04FF',
+    'arabic': r'\u0600-\u06FF',
+    'greek': r'\u0370-\u03FF',
+    'hebrew': r'\u0590-\u05FF',
+    'hindi': r'\u0900-\u097F',
+    'bengali': r'\u0980-\u09FF',
+    'chinese': r'\u4E00-\u9FFF',
+    'japanese': r'\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF',
+    'korean': r'\uAC00-\uD7AF',
+    'thai': r'\u0E00-\u0E7F',
+    'vietnamese': r'\u0041-\u005A\u0061-\u007A\u00C0-\u00FF\u0100-\u017F',
 }
 
 def create_language_filter(languages):
-    """
-    Create a filter function to detect specified language characters.
-    Numbers, punctuation, whitespace, emojis, and symbols are always allowed.
-    
-    Args:
-        languages: List of language names from LANGUAGE_RANGES
-    """
-    # Always allow:
-    # - Numbers (0-9), basic punctuation, spaces, and common symbols
-    # - Emojis and various symbol blocks
     base_pattern = (
-        r'\u0020-\u0040'  # Space to @
-        r'\u005B-\u0060'  # [ to `
-        r'\u007B-\u007E'  # { to ~
-        r'\u0009-\u000D'  # Tab, newline, etc.
-        r'\u0020'  # Space (redundant but explicit)
-        r'\u2000-\u206F'  # General Punctuation
-        r'\u2070-\u209F'  # Superscripts and Subscripts
-        r'\u20A0-\u20CF'  # Currency Symbols
-        r'\u2100-\u214F'  # Letterlike Symbols
-        r'\u2150-\u218F'  # Number Forms
-        r'\u2190-\u21FF'  # Arrows
-        r'\u2200-\u22FF'  # Mathematical Operators
-        r'\u2300-\u23FF'  # Miscellaneous Technical
-        r'\u2460-\u24FF'  # Enclosed Alphanumerics
-        r'\u2500-\u257F'  # Box Drawing
-        r'\u2580-\u259F'  # Block Elements
-        r'\u25A0-\u25FF'  # Geometric Shapes
-        r'\u2600-\u26FF'  # Miscellaneous Symbols
-        r'\u2700-\u27BF'  # Dingbats
-        r'\u2B00-\u2BFF'  # Miscellaneous Symbols and Arrows
+        r'\u0020-\u0040'    # Space to @
+        r'\u005B-\u0060'    # [ to `
+        r'\u007B-\u007E'    # { to ~
+        r'\u0009-\u000D'    # Tab, newline, etc.
+        r'\u0020'           # Space (redundant but explicit)
+        r'\u2000-\u206F'    # General Punctuation
+        r'\u2070-\u209F'    # Superscripts and Subscripts
+        r'\u20A0-\u20CF'    # Currency Symbols
+        r'\u2100-\u214F'    # Letterlike Symbols
+        r'\u2150-\u218F'    # Number Forms
+        r'\u2190-\u21FF'    # Arrows
+        r'\u2200-\u22FF'    # Mathematical Operators
+        r'\u2300-\u23FF'    # Miscellaneous Technical
+        r'\u2460-\u24FF'    # Enclosed Alphanumerics
+        r'\u2500-\u257F'    # Box Drawing
+        r'\u2580-\u259F'    # Block Elements
+        r'\u25A0-\u25FF'    # Geometric Shapes
+        r'\u2600-\u26FF'    # Miscellaneous Symbols
+        r'\u2700-\u27BF'    # Dingbats
+        r'\u2B00-\u2BFF'    # Miscellaneous Symbols and Arrows
         r'\u1F300-\u1F5FF'  # Miscellaneous Symbols and Pictographs
         r'\u1F600-\u1F64F'  # Emoticons
         r'\u1F680-\u1F6FF'  # Transport and Map Symbols
@@ -103,124 +75,48 @@ def create_language_filter(languages):
         r'\u1FA00-\u1FA6F'  # Chess Symbols
         r'\u1FA70-\u1FAFF'  # Symbols and Pictographs Extended-A
     )
-    
-    # Build character ranges from selected languages
+
     language_ranges = []
     for lang in languages:
         if lang.lower() in LANGUAGE_RANGES:
             language_ranges.append(LANGUAGE_RANGES[lang.lower()])
         else:
             print(f"[WARNING] Unknown language '{lang}', skipping...")
-    
+
     if not language_ranges:
         raise ValueError(f"No valid languages specified. Available languages: {list(LANGUAGE_RANGES.keys())}")
-    
-    # Combine base pattern with language ranges
+
     combined_pattern = base_pattern + ''.join(language_ranges)
     allowed_pattern = re.compile(f'^[{combined_pattern}]+$')
-    
+
     def filter_language(text):
-        """Check if text contains only allowed characters."""
         if not text:
             return False
         return bool(allowed_pattern.match(text))
-    
+
     return filter_language
 
 
-# TODO: This is also used in `unicode_language_filter.py`. The best solution is to 
-# make these utility functions available in a shared utils file.
-def is_messages_column(dataset, column_name):
-    """
-    Check if a column contains messages in the expected format.
-    
-    Args:
-        dataset: The dataset to check
-        column_name: Name of the column to check
-    
-    Returns:
-        bool: True if the column appears to be a messages column
-    """
-    if column_name not in dataset.column_names:
-        return False
-    
-    # Check the first non-null entry
-    for example in dataset:
-        value = example.get(column_name)
-        if value is None:
-            continue
-        
-        # Check if it's a list of dicts with 'content' key
-        if isinstance(value, list) and len(value) > 0:
-            if isinstance(value[0], dict) and 'content' in value[0]:
-                return True
-        break
-    
-    return False
-
-# TODO: This is also used in `unicode_language_filter.py`. The best solution is to 
-# make these utility functions available in a shared utils file.
-def flatten_messages(messages):
-    """
-    Flatten a messages list into a single text string.
-    
-    Args:
-        messages: List of message dictionaries with 'content' field
-    
-    Returns:
-        str: Flattened text with messages separated by newlines
-    """
-    if not messages:
-        return ""
-    
-    contents = []
-    for msg in messages:
-        if isinstance(msg, dict) and 'content' in msg:
-            content = msg['content']
-            if content:  # Only add non-empty content
-                contents.append(str(content))
-    
-    return '\n'.join(contents)
-
-
 def main(args):
-    # TODO: Create a unified loader that can handle both JSONL and Parquet, and HF Datasets.
-    # We already have a working example in `synthetic/utils.py` and `data/tokenization/utils.py`.
-    assert args.input_type in ["jsonl", "parquet"], "Dataset type must be either 'jsonl' or 'parquet'."
     assert args.output_type in ["jsonl", "parquet"], "Output type must be either 'jsonl' or 'parquet'."
-    
-    # Load dataset
+
+    loader = DatasetLoader(path=args.input_dir, cache_dir=args.cache_dir)
+    dataset = loader.load()
     data_files = glob.glob(f"{args.input_dir}/*.{args.input_type}")
-    if not data_files:
-        raise ValueError(f"No {args.input_type.upper()} files found in '{args.input_dir}'.")
-    
-    dataset = datasets.load_dataset(
-        "json" if args.input_type == "jsonl" else "parquet",
-        data_files=data_files,
-        split="train",
-        cache_dir=args.cache_dir,
-        num_proc=len(data_files),
-    )
-    print(f"[INFO] Loaded dataset with {len(dataset):,} examples from {args.input_type.upper()} files.")
-    print(f"[INFO] Columns: {dataset.column_names}")
-    
-    # Verify text column exists
+
     if args.text_column not in dataset.column_names:
         raise ValueError(f"Column '{args.text_column}' not found in dataset. Available columns: {dataset.column_names}")
-    
-    # Check if the column is a messages column
+
     is_messages = is_messages_column(dataset, args.text_column)
     if is_messages:
         print(f"[INFO] Detected messages format in column '{args.text_column}'")
         print("[INFO] Messages will be flattened before filtering")
-    
-    # Calculate initial token count if column exists
+
     original_count = len(dataset)
     if 'token_count' in dataset.column_names:
         original_tokens = sum(dataset['token_count'])
         print(f"[INFO] Original tokens: {original_tokens:,}")
-    
-    # Filter out non-matching language samples
+
     if args.save_excluded:
         print(f"\n[INFO] Saving EXCLUDED samples (those NOT matching: {', '.join(args.languages)})")
         print("[INFO] (Numbers, punctuation, spaces, emojis, and symbols are always allowed)")
@@ -228,32 +124,26 @@ def main(args):
         print(f"\n[INFO] Filtering samples to keep only: {', '.join(args.languages)}")
         print("[INFO] (Numbers, punctuation, spaces, emojis, and symbols are always allowed)")
     language_filter = create_language_filter(args.languages)
-    
-    # Create a modified filter that works with the specified text column
+
     def filter_with_column(example):
         value = example[args.text_column]
-        
-        # Handle messages column
         if is_messages:
             text = flatten_messages(value)
         else:
             text = value
-        
         result = language_filter(text)
-        # Invert the filter if we want to save excluded samples
         return not result if args.save_excluded else result
-    
+
     filtered_dataset = dataset.filter(
         filter_with_column,
         num_proc=args.num_proc or 1,
         desc="Filtering by language",
     )
-    
-    # Calculate statistics
+
     filtered_count = len(filtered_dataset)
     removed_count = original_count - filtered_count
     removed_percentage = (removed_count / original_count * 100) if original_count > 0 else 0
-    
+
     print(f"\n[INFO] ===== FILTERING RESULTS =====")
     print(f"[INFO] Original samples: {original_count:,}")
     if args.save_excluded:
@@ -262,7 +152,7 @@ def main(args):
     else:
         print(f"[INFO] Filtered samples: {filtered_count:,}")
         print(f"[INFO] Removed samples: {removed_count:,} ({removed_percentage:.2f}%)")
-    
+
     if 'token_count' in filtered_dataset.column_names:
         filtered_tokens = sum(filtered_dataset['token_count'])
         removed_tokens = original_tokens - filtered_tokens
@@ -270,46 +160,13 @@ def main(args):
         print(f"[INFO] Original tokens: {original_tokens:,}")
         print(f"[INFO] Filtered tokens: {filtered_tokens:,}")
         print(f"[INFO] Removed tokens: {removed_tokens:,} ({removed_tokens_percentage:.2f}%)")
-    
+
     if filtered_count == 0:
         print("[WARNING] No samples remaining after filtering. Not saving dataset.")
         return
-    
-    # Create output directory
-    os.makedirs(args.output_dir, exist_ok=True)
 
-    # TODO: Chunking and saving logic is duplicated from `unicode_language_filter.py`. 
-    # We should unify this in a shared utility function.
-    # See `data/tokenization/utils.py` for an example of how to implement this in a reusable way.
-    
-    # Determine number of chunks (equal to number of input files)
-    n_chunks = len(data_files)
-    print(f"\n[INFO] Splitting dataset into {n_chunks} chunks (matching input file count)")
-    
-    # Split dataset into chunks
-    indices = np.array_split(np.arange(filtered_count), n_chunks)
-    chunks = [filtered_dataset.select(idx.tolist()) for idx in indices if len(idx) > 0]
-    
-    # Save chunks
-    extension = args.output_type if args.output_type == "parquet" else "jsonl"
-    save_fn = lambda chunk, path: (
-        chunk.to_parquet(path) if args.output_type == "parquet" else chunk.to_json(path)
-    )
-    
-    for i, chunk in enumerate(chunks):
-        filename = f"{args.output_dir}/train-{i:05d}-of-{n_chunks:05d}.{extension}"
-        save_fn(chunk, filename)
-        print(f"[INFO] Saved chunk {i+1}/{n_chunks} with {len(chunk):,} examples to {filename}")
-    
-    # Save metadata
-    with open(f"{args.output_dir}/.metadata", "w") as meta_file:
-        meta_file.write(f"Number of samples: {filtered_count}\n")
-        if 'token_count' in filtered_dataset.column_names:
-            meta_file.write(f"Number of tokens: {filtered_tokens}\n")
-        meta_file.write(f"Chunks: {n_chunks}\n")
-        meta_file.write(f"Columns: {filtered_dataset.column_names}\n")
-    
-    print("\n[INFO] Metadata saved to .metadata file")
+    filtered_tokens = sum(filtered_dataset['token_count']) if 'token_count' in filtered_dataset.column_names else 0
+    save_dataset(filtered_dataset, args.output_dir, args.output_type, tokens_per_chunk=1_000_000, token_count=filtered_tokens, n_chunks=len(data_files))
     print("\n[INFO] Language filtering complete!")
 
 
@@ -318,20 +175,18 @@ if __name__ == "__main__":
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    
-    parser.add_argument("--input_dir", type=str, required=True, help="Directory containing the input dataset files")
-    parser.add_argument("--output_dir", type=str, required=True, help="Output directory to save filtered dataset")
-    parser.add_argument("--languages", type=str, nargs='+', required=True, 
-                        help=f"Languages to keep (space-separated). Available: {', '.join(sorted(LANGUAGE_RANGES.keys()))}")
-    parser.add_argument("--input_type", choices=["jsonl", "parquet"], default="parquet", help="Type of the input files")
-    parser.add_argument("--output_type", choices=["jsonl", "parquet"], default="parquet", help="Type of the output files")
-    parser.add_argument("--text_column", type=str, default="text", help="Name of the text column in the dataset")
-    parser.add_argument("--cache_dir", type=str, help="Cache directory for dataset loading")
-    parser.add_argument("--num_proc", type=int, default=8, help="Number of processes to use")
-    parser.add_argument("--save_excluded", action="store_true", help="Save excluded samples instead of included ones (for testing)")
-    
+    parser.add_argument("--input_dir", type=str, required=True)
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--languages", type=str, nargs='+', required=True,
+                        help=f"Languages to keep. Available: {', '.join(sorted(LANGUAGE_RANGES.keys()))}")
+    parser.add_argument("--input_type", choices=["jsonl", "parquet"], default="parquet")
+    parser.add_argument("--output_type", choices=["jsonl", "parquet"], default="parquet")
+    parser.add_argument("--text_column", type=str, default="text")
+    parser.add_argument("--cache_dir", type=str)
+    parser.add_argument("--num_proc", type=int, default=8)
+    parser.add_argument("--save_excluded", action="store_true")
+
     args = parser.parse_args()
-    
     print(f"Filtering dataset for {', '.join(args.languages)} text only...")
     main(args)
     print("Done! 🎆")

--- a/data/filters/utils.py
+++ b/data/filters/utils.py
@@ -1,0 +1,104 @@
+"""
+Shared utilities for language filter scripts.
+"""
+import glob
+import os
+import numpy as np
+import datasets
+
+
+class DatasetLoader:
+    """Loads datasets from a local file, local directory, or HuggingFace Hub.
+    Source type is detected automatically:
+    - Directory  -> all .jsonl or .parquet files inside are loaded.
+    - Local file -> .jsonl or .parquet are supported.
+    - Anything else is treated as a HuggingFace Hub dataset identifier.
+    """
+    _FILE_FORMATS = {".jsonl": "json", ".json": "json", ".parquet": "parquet"}
+
+    def __init__(self, path, cache_dir=None, seed=None, split="train", subset=None):
+        self.path = path
+        self.cache_dir = cache_dir
+        self.seed = seed
+        self.split = split
+        self.subset = subset
+
+    def load(self):
+        if os.path.isdir(self.path):
+            dataset = self._from_directory()
+        elif os.path.isfile(self.path):
+            dataset = self._from_file()
+        else:
+            dataset = self._from_hf()
+        return dataset.shuffle(seed=self.seed) if self.seed is not None else dataset
+
+    def _from_file(self):
+        ext = os.path.splitext(self.path)[1].lower()
+        fmt = self._FILE_FORMATS.get(ext)
+        if fmt is None:
+            raise ValueError(f"Unsupported file format '{ext}'. Expected .jsonl or .parquet.")
+        return datasets.load_dataset(fmt, data_files=self.path, split="train", cache_dir=self.cache_dir)
+
+    def _from_directory(self):
+        for ext, fmt in (("*.jsonl", "json"), ("*.parquet", "parquet")):
+            files = sorted(glob.glob(os.path.join(self.path, ext)))
+            if files:
+                return datasets.load_dataset(
+                    fmt,
+                    data_files=files,
+                    split="train",
+                    num_proc=len(files),
+                    cache_dir=self.cache_dir,
+                )
+        raise ValueError(f"No .jsonl or .parquet files found in '{self.path}'.")
+
+    def _from_hf(self):
+        load_args = {"path": self.path, "split": self.split, "cache_dir": self.cache_dir}
+        if self.subset is not None:
+            load_args["name"] = self.subset
+        return datasets.load_dataset(**load_args)
+
+
+def save_dataset(dataset, output_dir, output_type, tokens_per_chunk, token_count, *, n_chunks=None):
+    sample_count = len(dataset)
+    if sample_count == 0:
+        return 0
+    if n_chunks is None:
+        n_chunks = max(1, (token_count + tokens_per_chunk - 1) // tokens_per_chunk)
+    indices = np.array_split(np.arange(sample_count), n_chunks)
+    os.makedirs(output_dir, exist_ok=True)
+    extension = "parquet" if output_type == "parquet" else "jsonl"
+    for i, idx in enumerate(indices):
+        chunk = dataset.select(idx)
+        filename = os.path.join(output_dir, f"train-{i:05d}-of-{n_chunks:05d}.{extension}")
+        if output_type == "parquet":
+            chunk.to_parquet(filename)
+        else:
+            chunk.to_json(filename)
+    return n_chunks
+
+
+def is_messages_column(dataset, column_name):
+    if column_name not in dataset.column_names:
+        return False
+    for example in dataset:
+        value = example.get(column_name)
+        if value is None:
+            continue
+        if isinstance(value, list) and len(value) > 0:
+            if isinstance(value[0], dict) and 'content' in value[0]:
+                return True
+        break
+    return False
+
+
+def flatten_messages(messages):
+    if not messages:
+        return ""
+    contents = []
+    for msg in messages:
+        if isinstance(msg, dict) and 'content' in msg:
+            content = msg['content']
+            if content:
+                contents.append(str(content))
+    return '\n'.join(contents)


### PR DESCRIPTION
Refactor: Extract shared dataset loading logic into utils.py
This PR refactors the duplicated code across langdetect_language_filter.py and unicode_language_filter.py into a shared utils.py file.

Changes include:

- Created data/filters/utils.py with shared utilities:

- DatasetLoader class for loading datasets from local files, directories, or HuggingFace Hub
- save_dataset() for splitting and saving datasets to disk in chunks
- is_messages_column() for detecting chat-style message columns
- flatten_messages() for flattening message lists into plain text

- Updated both filter scripts to import from utils.py instead of duplicating the logic
- Removed about 400 lines of duplicated code across the two scripts