### PR TITLE
Refactor duplicated utilities into shared modules

### DIFF
--- a/data/cc/utils.py
+++ b/data/cc/utils.py
@@ -2,9 +2,6 @@
 Shared utilities for CommonCrawl processing scripts.
 """
 
-import glob
-import json
-import os
 import sys
 from pathlib import Path
 
@@ -15,93 +12,3 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from shared.logging import get_logger as get_logger  # noqa: E402
-
-
-def read_metadata(metadata_file: str) -> dict | None:
-    """
-    Read metadata from a file in YAML-like key: value format.
-
-    Args:
-        metadata_file: Path to the metadata file.
-
-    Returns:
-        Dictionary with metadata values, or None if the file does not exist.
-    """
-    if not os.path.exists(metadata_file):
-        return None
-
-    metadata = {}
-    with open(metadata_file, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line and ":" in line:
-                key, value = line.split(":", 1)
-                key = key.strip()
-                value = value.strip()
-                try:
-                    if "." in value:
-                        metadata[key] = float(value)
-                    else:
-                        metadata[key] = int(value)
-                except ValueError:
-                    metadata[key] = value
-    return metadata
-
-
-def write_metadata(metadata_file: str, metadata: dict) -> None:
-    """
-    Write metadata to a file in YAML-like key: value format.
-
-    Args:
-        metadata_file: Path to the metadata file to write.
-        metadata: Dictionary of metadata values to persist.
-    """
-    with open(metadata_file, "w", encoding="utf-8") as f:
-        for key, value in metadata.items():
-            f.write(f"{key}: {value}\n")
-
-
-def initialize_or_load_metadata(lang_output_path: str) -> dict:
-    """
-    Return metadata for a language output folder.
-
-    Loads from an existing `.metadata` file if present. Otherwise scans all
-    JSONL files in the folder to rebuild the statistics and writes the result
-    to `.metadata` for future calls.
-
-    Args:
-        lang_output_path: Path to the language-specific output folder.
-
-    Returns:
-        Dictionary with at least `lines` and `tokens` keys.
-    """
-    metadata_file = os.path.join(lang_output_path, ".metadata")
-
-    metadata = read_metadata(metadata_file)
-    if metadata is not None:
-        return metadata
-
-    all_jsonl_files = glob.glob(os.path.join(lang_output_path, "*.jsonl"))
-
-    if not all_jsonl_files:
-        return {"lines": 0, "tokens": 0}
-
-    total_lines = 0
-    total_tokens = 0
-
-    for jsonl_file in all_jsonl_files:
-        with open(jsonl_file, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                    total_lines += 1
-                    total_tokens += data.get("token_count", 0)
-                except json.JSONDecodeError:
-                    continue
-
-    metadata = {"lines": total_lines, "tokens": total_tokens}
-    write_metadata(metadata_file, metadata)
-    return metadata

--- a/data/filters/utils.py
+++ b/data/filters/utils.py
@@ -2,9 +2,6 @@
 Shared utilities for filtering and annotation scripts.
 """
 
-import glob
-import json
-import os
 import sys
 from pathlib import Path
 
@@ -17,96 +14,6 @@ if str(_REPO_ROOT) not in sys.path:
 from shared.dataset_loader import DatasetLoader as DatasetLoader  # noqa: E402
 from shared.logging import get_logger as get_logger  # noqa: E402
 from shared.save_dataset import save_dataset as save_dataset  # noqa: E402
-
-
-def read_metadata(metadata_file: str) -> dict | None:
-    """
-    Read metadata from a file in YAML-like key: value format.
-
-    Args:
-        metadata_file: Path to the metadata file.
-
-    Returns:
-        Dictionary with metadata values, or None if the file does not exist.
-    """
-    if not os.path.exists(metadata_file):
-        return None
-
-    metadata = {}
-    with open(metadata_file, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line and ":" in line:
-                key, value = line.split(":", 1)
-                key = key.strip()
-                value = value.strip()
-                try:
-                    if "." in value:
-                        metadata[key] = float(value)
-                    else:
-                        metadata[key] = int(value)
-                except ValueError:
-                    metadata[key] = value
-    return metadata
-
-
-def write_metadata(metadata_file: str, metadata: dict) -> None:
-    """
-    Write metadata to a file in YAML-like key: value format.
-
-    Args:
-        metadata_file: Path to the metadata file to write.
-        metadata: Dictionary of metadata values to persist.
-    """
-    with open(metadata_file, "w", encoding="utf-8") as f:
-        for key, value in metadata.items():
-            f.write(f"{key}: {value}\n")
-
-
-def initialize_or_load_metadata(lang_output_path: str) -> dict:
-    """
-    Return metadata for a language output folder.
-
-    Loads from an existing `.metadata` file if present. Otherwise scans all
-    JSONL files in the folder to rebuild the statistics and writes the result
-    to `.metadata` for future calls.
-
-    Args:
-        lang_output_path: Path to the language-specific output folder.
-
-    Returns:
-        Dictionary with at least `lines` and `tokens` keys.
-    """
-    metadata_file = os.path.join(lang_output_path, ".metadata")
-
-    metadata = read_metadata(metadata_file)
-    if metadata is not None:
-        return metadata
-
-    all_jsonl_files = glob.glob(os.path.join(lang_output_path, "*.jsonl"))
-
-    if not all_jsonl_files:
-        return {"lines": 0, "tokens": 0}
-
-    total_lines = 0
-    total_tokens = 0
-
-    for jsonl_file in all_jsonl_files:
-        with open(jsonl_file, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    data = json.loads(line)
-                    total_lines += 1
-                    total_tokens += data.get("token_count", 0)
-                except json.JSONDecodeError:
-                    continue
-
-    metadata = {"lines": total_lines, "tokens": total_tokens}
-    write_metadata(metadata_file, metadata)
-    return metadata
 
 
 def is_messages_column(dataset, column_name):

--- a/data/formatting/utils.py
+++ b/data/formatting/utils.py
@@ -2,7 +2,6 @@
 Utilities for data preprocessing.
 """
 
-import glob
 import importlib.util
 import json
 import os
@@ -18,37 +17,10 @@ while not (_REPO_ROOT / "pyproject.toml").exists() and _REPO_ROOT.parent != _REP
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from shared.infer_file_features import infer_file_features  # noqa: E402
+from shared.list_matching_files import list_matching_files  # noqa: E402
 from shared.logging import get_logger as get_logger  # noqa: E402
-
-
-def save_metadata(output_dir, **kwargs):
-    """Write key-value metadata to `<output_dir>/.metadata`."""
-    os.makedirs(output_dir, exist_ok=True)
-    with open(os.path.join(output_dir, ".metadata"), "w") as f:
-        for key, value in kwargs.items():
-            f.write(f"{key}: {value}\n")
-
-
-def list_matching_files(directory: str, *patterns: str) -> list[str]:
-    """Return a sorted list of files in `directory` matching any glob pattern."""
-    matches: set[str] = set()
-    for pattern in patterns:
-        matches.update(glob.glob(os.path.join(directory, pattern)))
-    return sorted(matches)
-
-
-def infer_file_features(file_path: str, output_type: str) -> list[str]:
-    """Infer output feature names from a written parquet or jsonl shard."""
-    if output_type == "parquet":
-        import pyarrow.parquet as pq
-
-        return list(pq.read_schema(file_path).names)
-
-    with open(file_path, encoding="utf-8") as fh:
-        line = fh.readline()
-        if not line.strip():
-            return []
-        return list(json.loads(line).keys())
+from shared.save_metadata import save_metadata  # noqa: E402
 
 
 @dataclass(frozen=True)

--- a/data/tokenization/utils.py
+++ b/data/tokenization/utils.py
@@ -2,9 +2,6 @@
 Shared utilities for tokenization and packing scripts.
 """
 
-import glob
-import json
-import os
 import sys
 from pathlib import Path
 
@@ -17,33 +14,3 @@ if str(_REPO_ROOT) not in sys.path:
 from shared.dataset_loader import DatasetLoader as DatasetLoader  # noqa: E402
 from shared.logging import get_logger as get_logger  # noqa: E402
 from shared.save_dataset import save_dataset as save_dataset  # noqa: E402
-
-
-def save_metadata(output_dir, **kwargs):
-    """Write key-value metadata to `<output_dir>/.metadata`."""
-    os.makedirs(output_dir, exist_ok=True)
-    with open(os.path.join(output_dir, ".metadata"), "w") as f:
-        for key, value in kwargs.items():
-            f.write(f"{key}: {value}\n")
-
-
-def list_matching_files(directory: str, *patterns: str) -> list[str]:
-    """Return a sorted list of files in `directory` matching any glob pattern."""
-    matches: set[str] = set()
-    for pattern in patterns:
-        matches.update(glob.glob(os.path.join(directory, pattern)))
-    return sorted(matches)
-
-
-def infer_file_features(file_path: str, output_type: str) -> list[str]:
-    """Infer output feature names from a written parquet or jsonl shard."""
-    if output_type == "parquet":
-        import pyarrow.parquet as pq
-
-        return list(pq.read_schema(file_path).names)
-
-    with open(file_path, encoding="utf-8") as fh:
-        line = fh.readline()
-        if not line.strip():
-            return []
-        return list(json.loads(line).keys())

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -2,6 +2,13 @@
 
 Modules:
     - dataset_loader: DatasetLoader
+    - infer_file_features: infer_file_features
+    - initialize_or_load_metadata: initialize_or_load_metadata
+    - list_matching_files: list_matching_files
     - logging: get_logger
+    - read_metadata: read_metadata
     - save_dataset: save_dataset
+    - save_metadata: save_metadata
+    - write_metadata: write_metadata
+
 """

--- a/shared/infer_file_features.py
+++ b/shared/infer_file_features.py
@@ -1,0 +1,15 @@
+import json
+
+
+def infer_file_features(file_path: str, output_type: str) -> list[str]:
+    """Infer output feature names from a written parquet or jsonl shard."""
+    if output_type == "parquet":
+        import pyarrow.parquet as pq
+
+        return list(pq.read_schema(file_path).names)
+
+    with open(file_path, encoding="utf-8") as fh:
+        line = fh.readline()
+        if not line.strip():
+            return []
+        return list(json.loads(line).keys())

--- a/shared/initialize_or_load_metadata.py
+++ b/shared/initialize_or_load_metadata.py
@@ -1,0 +1,52 @@
+import glob
+import json
+import os
+
+from shared.read_metadata import read_metadata
+from shared.write_metadata import write_metadata
+
+
+def initialize_or_load_metadata(lang_output_path: str) -> dict:
+    """
+    Return metadata for a language output folder.
+
+    Loads from an existing `.metadata` file if present. Otherwise scans all
+    JSONL files in the folder to rebuild the statistics and writes the result
+    to `.metadata` for future calls.
+
+    Args:
+        lang_output_path: Path to the language-specific output folder.
+
+    Returns:
+        Dictionary with at least `lines` and `tokens` keys.
+    """
+    metadata_file = os.path.join(lang_output_path, ".metadata")
+
+    metadata = read_metadata(metadata_file)
+    if metadata is not None:
+        return metadata
+
+    all_jsonl_files = glob.glob(os.path.join(lang_output_path, "*.jsonl"))
+
+    if not all_jsonl_files:
+        return {"lines": 0, "tokens": 0}
+
+    total_lines = 0
+    total_tokens = 0
+
+    for jsonl_file in all_jsonl_files:
+        with open(jsonl_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                    total_lines += 1
+                    total_tokens += data.get("token_count", 0)
+                except json.JSONDecodeError:
+                    continue
+
+    metadata = {"lines": total_lines, "tokens": total_tokens}
+    write_metadata(metadata_file, metadata)
+    return metadata

--- a/shared/list_matching_files.py
+++ b/shared/list_matching_files.py
@@ -1,0 +1,10 @@
+import glob
+import os
+
+
+def list_matching_files(directory: str, *patterns: str) -> list[str]:
+    """Return a sorted list of files in `directory` matching any glob pattern."""
+    matches: set[str] = set()
+    for pattern in patterns:
+        matches.update(glob.glob(os.path.join(directory, pattern)))
+    return sorted(matches)

--- a/shared/read_metadata.py
+++ b/shared/read_metadata.py
@@ -1,0 +1,32 @@
+import os
+
+
+def read_metadata(metadata_file: str) -> dict | None:
+    """
+    Read metadata from a file in YAML-like key: value format.
+
+    Args:
+        metadata_file: Path to the metadata file.
+
+    Returns:
+        Dictionary with metadata values, or None if the file does not exist.
+    """
+    if not os.path.exists(metadata_file):
+        return None
+
+    metadata = {}
+    with open(metadata_file, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and ":" in line:
+                key, value = line.split(":", 1)
+                key = key.strip()
+                value = value.strip()
+                try:
+                    if "." in value:
+                        metadata[key] = float(value)
+                    else:
+                        metadata[key] = int(value)
+                except ValueError:
+                    metadata[key] = value
+    return metadata

--- a/shared/save_metadata.py
+++ b/shared/save_metadata.py
@@ -1,0 +1,9 @@
+import os
+
+
+def save_metadata(output_dir, **kwargs):
+    """Write key-value metadata to `<output_dir>/.metadata`."""
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, ".metadata"), "w") as f:
+        for key, value in kwargs.items():
+            f.write(f"{key}: {value}\n")

--- a/shared/write_metadata.py
+++ b/shared/write_metadata.py
@@ -1,0 +1,11 @@
+def write_metadata(metadata_file: str, metadata: dict) -> None:
+    """
+    Write metadata to a file in YAML-like key: value format.
+
+    Args:
+        metadata_file: Path to the metadata file to write.
+        metadata: Dictionary of metadata values to persist.
+    """
+    with open(metadata_file, "w", encoding="utf-8") as f:
+        for key, value in metadata.items():
+            f.write(f"{key}: {value}\n")


### PR DESCRIPTION
# What does this PR do?

<!--
Thanks for your contribution! 🎉

This refactoring removes duplicated utility functions from several local `utils.py` modules within the data folder (so all the utils.py in ' data/tokenization, formatting, filters, and cc) and consolidates them into reusable modules within the `shared` directory. Functions for reading and writing metadata, saving metadata, matching files, inferring file features, and initializing metadata are now maintained in one central location rather than being independently implemented across multiple files. The relevant local `utils.py` modules import these shared implementations, reducing code duplication and making future maintenance easier. The `shared` package also re-exports the appropriate utilities so they can be accessed consistently throughout the project.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to @-mention
the maintainers (@Nkluge-correa or @shiza-fatimah) or other contributors who may be interested in
your PR.
