### PR TITLE
Allow common crawl extraction scripts to use faster queues

### DIFF
--- a/data/cc/slurm/process_cc_dump_all_languages.sh
+++ b/data/cc/slurm/process_cc_dump_all_languages.sh
@@ -11,6 +11,12 @@
 #
 # Learn about Marvin|Bender dual software stacks at:
 # - https://wiki.hpc.uni-bonn.de/en/dualstacks
+#
+#
+# This script overlaps download and compute.
+# While the current batch of WARC files is being processed, the next batch is downloaded in the background.
+# Trade-off: Peak disk usage roughly doubles compared to the sequential approach.
+#
 #############################################
 #SBATCH --account=ag_bit_flek              # <-- Change to your SLURM account
 #SBATCH --partition=lm_long                # <-- Change to your partition
@@ -78,22 +84,39 @@ echo "# [${SLURM_JOB_ID}] Python executable: $(which python3) — $(python3 --ve
 #############################################
 # Job Time Management Functions
 #############################################
+duration_to_seconds() {
+    local t="$1"
+    local days=0
+    local rest="$t"
+    if [[ "$t" == *-* ]]; then
+        days=${t%%-*}
+        rest=${t#*-}
+    fi
+    local h=0 m=0 s=0
+    IFS=: read -r h m s <<< "$rest"
+    # 10# forces base-10; avoids "value too great for base" on zero-padded "08".
+    echo $(( (10#$days)*86400 + (10#$h)*3600 + (10#$m)*60 + (10#$s) ))
+}
+
 get_remaining_seconds() {
-    local job_start=$(squeue -j $SLURM_JOB_ID -h -o %S 2>/dev/null || echo "")
-    local job_timelimit=$(squeue -j $SLURM_JOB_ID -h -o %l 2>/dev/null || echo "7-00:00:00")
+    # SLURM_JOB_END_TIME: projected end as a UNIX timestamp (seconds).
+    # Handles any --time format, including sub-day limits.
+    if [[ -n "${SLURM_JOB_END_TIME:-}" ]]; then
+        echo $(( SLURM_JOB_END_TIME - $(date +%s) ))
+        return
+    fi
 
-    # Convert time limit to seconds (assuming format like "7-00:00:00")
-    local days=$(echo $job_timelimit | cut -d'-' -f1)
-    local time_part=$(echo $job_timelimit | cut -d'-' -f2)
-    local hours=$(echo $time_part | cut -d':' -f1)
-    local minutes=$(echo $time_part | cut -d':' -f2)
-    local seconds=$(echo $time_part | cut -d':' -f3)
-
-    local total_seconds=$((days * 86400 + hours * 3600 + minutes * 60 + seconds))
-    local elapsed_seconds=$SECONDS
-    local remaining=$((total_seconds - elapsed_seconds))
-
-    echo $remaining
+    # Fallback: parse squeue %l. SLURM emits "D-HH:MM:SS" only when >= 1 day,
+    # and "HH:MM:SS" otherwise.
+    local job_timelimit
+    job_timelimit=$(squeue -j "$SLURM_JOB_ID" -h -o %l 2>/dev/null || echo "")
+    if [[ -z "$job_timelimit" || "$job_timelimit" == "UNLIMITED" ]]; then
+        echo 999999999
+        return
+    fi
+    local total_seconds
+    total_seconds=$(duration_to_seconds "$job_timelimit")
+    echo $(( total_seconds - SECONDS ))
 }
 
 count_available_warc_paths() {
@@ -140,6 +163,18 @@ find "$WARC_FILES_FOLDER" -mindepth 1 -delete 2>/dev/null || true
 find "$LOGS_FOLDER" -mindepth 1 -delete 2>/dev/null || true
 find "$TEMP_OUTPUT_FOLDER" -mindepth 1 -delete 2>/dev/null || true
 
+# We handle two separate buffers to allow simultaneous downloading and processing of WARC files.
+WARC_BUFFER_A="$WARC_FILES_FOLDER/buf_a"
+WARC_BUFFER_B="$WARC_FILES_FOLDER/buf_b"
+mkdir -p "$WARC_BUFFER_A" "$WARC_BUFFER_B"
+
+active_dir="$WARC_BUFFER_A"
+staging_dir="$WARC_BUFFER_B"
+
+# Prime the first buffer before the loop.
+bash "$workdir/warc_files_download.sh" "$WARCS_PER_CICLE" "$DUMP" \
+    --remove-downloaded --download-dir "$active_dir" >/dev/null 2>&1
+
 while true; do
     remaining_time=$(get_remaining_seconds)
 
@@ -165,17 +200,21 @@ while true; do
     #############################################
     # Download Warcs
     #############################################
-    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Starting download phase" >> "$out"
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Starting download in background" >> "$out"
     echo "# [${SLURM_JOB_ID}] Processing DUMP: $DUMP" >> "$out"
-    bash $workdir/warc_files_download.sh $WARCS_PER_CICLE $DUMP --remove-downloaded >/dev/null 2>&1 &
-    wait
+
+    # Download the next batch in the background while we compute.
+    bash $workdir/warc_files_download.sh $WARCS_PER_CICLE $DUMP --remove-downloaded --download-dir $staging_dir >/dev/null 2>&1 &
+    download_pid=$!
 
     #############################################
     # Language Filtering Processing
     #############################################
     echo "# [${SLURM_JOB_ID}] Iteration $iteration: Starting language filtering of warcs" >> "$out"
+
+    # Process the current buffer in the foreground.
     python3 -u "$workdir/llm-foundry/data/cc/process_cc_dump_all_languages.py" \
-        --warc_files_folder "$WARC_FILES_FOLDER" \
+        --warc_files_folder "$active_dir" \
         --temp_output_folder "$TEMP_OUTPUT_FOLDER" \
         --output_folder "$OUTPUT_FOLDER" \
         --logs_folder "$LOGS_FOLDER" \
@@ -186,9 +225,25 @@ while true; do
         --expand_metadata \
         --tasks $SLURM_CPUS_PER_TASK \
         --workers $SLURM_CPUS_PER_TASK 1>>"$out" 2>>"$err" &
-    wait
+    process_pid=$!
 
-    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Processing completed" >> "$out"
+    #############################################
+    # Swap Buffers
+    #############################################
+
+    # Wait for both downloading and processing before swapping, so the staging buffer is complete.
+    wait "$download_pid" "$process_pid"
+
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Processing current warcs completed" >> "$out"
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Downloading warcs for next iteration completed" >> "$out"
+
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Swapping buffers" >> "$out"
+
+    # Swapping buffers
+    tmp="$active_dir"; active_dir="$staging_dir"; staging_dir="$tmp"
+
+    # Clear the just-consumed buffer for its next reuse.
+    find "$staging_dir" -mindepth 1 -delete 2>/dev/null || true
 
     #############################################
     # Split Large JSONL Files
@@ -220,7 +275,6 @@ while true; do
     # Delete the content of temporary folders
     #############################################
     echo "# [${SLURM_JOB_ID}] Iteration $iteration: Cleaning up temporary files" >> "$out"
-    find "$WARC_FILES_FOLDER" -mindepth 1 -delete 2>/dev/null || true
     find "$LOGS_FOLDER" -mindepth 1 -delete 2>/dev/null || true
     find "$TEMP_OUTPUT_FOLDER" -mindepth 1 -delete 2>/dev/null || true
 
@@ -258,6 +312,12 @@ while true; do
     # Brief pause between iterations
     sleep 60
 done
+
+# Clear buffers
+echo "# [${SLURM_JOB_ID}] Clearing buffers" >> "$out"
+find "$WARC_BUFFER_A" -mindepth 1 -delete 2>/dev/null || true
+find "$WARC_BUFFER_B" -mindepth 1 -delete 2>/dev/null || true
+
 
 #############################################
 # End of Script

--- a/data/cc/slurm/process_cc_dump_with_quality_filters.sh
+++ b/data/cc/slurm/process_cc_dump_with_quality_filters.sh
@@ -82,22 +82,39 @@ echo "# [${SLURM_JOB_ID}] Python executable: $(which python3) — $(python3 --ve
 #############################################
 # Job Time Management Functions
 #############################################
+duration_to_seconds() {
+    local t="$1"
+    local days=0
+    local rest="$t"
+    if [[ "$t" == *-* ]]; then
+        days=${t%%-*}
+        rest=${t#*-}
+    fi
+    local h=0 m=0 s=0
+    IFS=: read -r h m s <<< "$rest"
+    # 10# forces base-10; avoids "value too great for base" on zero-padded "08".
+    echo $(( (10#$days)*86400 + (10#$h)*3600 + (10#$m)*60 + (10#$s) ))
+}
+
 get_remaining_seconds() {
-    local job_start=$(squeue -j $SLURM_JOB_ID -h -o %S 2>/dev/null || echo "")
-    local job_timelimit=$(squeue -j $SLURM_JOB_ID -h -o %l 2>/dev/null || echo "7-00:00:00")
+    # SLURM_JOB_END_TIME: projected end as a UNIX timestamp (seconds).
+    # Handles any --time format, including sub-day limits.
+    if [[ -n "${SLURM_JOB_END_TIME:-}" ]]; then
+        echo $(( SLURM_JOB_END_TIME - $(date +%s) ))
+        return
+    fi
 
-    # Convert time limit to seconds (assuming format like "7-00:00:00")
-    local days=$(echo $job_timelimit | cut -d'-' -f1)
-    local time_part=$(echo $job_timelimit | cut -d'-' -f2)
-    local hours=$(echo $time_part | cut -d':' -f1)
-    local minutes=$(echo $time_part | cut -d':' -f2)
-    local seconds=$(echo $time_part | cut -d':' -f3)
-
-    local total_seconds=$((days * 86400 + hours * 3600 + minutes * 60 + seconds))
-    local elapsed_seconds=$SECONDS
-    local remaining=$((total_seconds - elapsed_seconds))
-
-    echo $remaining
+    # Fallback: parse squeue %l. SLURM emits "D-HH:MM:SS" only when >= 1 day,
+    # and "HH:MM:SS" otherwise.
+    local job_timelimit
+    job_timelimit=$(squeue -j "$SLURM_JOB_ID" -h -o %l 2>/dev/null || echo "")
+    if [[ -z "$job_timelimit" || "$job_timelimit" == "UNLIMITED" ]]; then
+        echo 999999999
+        return
+    fi
+    local total_seconds
+    total_seconds=$(duration_to_seconds "$job_timelimit")
+    echo $(( total_seconds - SECONDS ))
 }
 
 count_available_warc_paths() {
@@ -145,6 +162,18 @@ find "$LOGS_FOLDER" -mindepth 1 -delete 2>/dev/null || true
 find "$WARC_EXTRACTION_OUTPUT" -mindepth 1 -delete 2>/dev/null || true
 find "$QUALITY_FILTER_OUTPUT" -mindepth 1 -delete 2>/dev/null || true
 
+# We handle two separate buffers to allow simultaneous downloading and processing of WARC files.
+WARC_BUFFER_A="$WARC_FILES_FOLDER/buf_a"
+WARC_BUFFER_B="$WARC_FILES_FOLDER/buf_b"
+mkdir -p "$WARC_BUFFER_A" "$WARC_BUFFER_B"
+
+active_dir="$WARC_BUFFER_A"
+staging_dir="$WARC_BUFFER_B"
+
+# Prime the first buffer before the loop.
+bash "$workdir/warc_files_download.sh" "$WARCS_PER_CICLE" "$DUMP" \
+    --remove-downloaded --download-dir "$active_dir" >/dev/null 2>&1
+
 while true; do
     remaining_time=$(get_remaining_seconds)
 
@@ -170,10 +199,10 @@ while true; do
     #############################################
     # Download Warcs
     #############################################
-    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Starting download phase" >> "$out"
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Starting download in background" >> "$out"
     echo "# [${SLURM_JOB_ID}] Processing DUMP: $DUMP" >> "$out"
-    bash $workdir/warc_files_download.sh $WARCS_PER_CICLE $DUMP --remove-downloaded >/dev/null 2>&1 &
-    wait
+    bash $workdir/warc_files_download.sh $WARCS_PER_CICLE $DUMP --remove-downloaded --download-dir "$staging_dir" >/dev/null 2>&1 &
+    download_pid=$!
 
     #############################################
     # Pre-processing & Post-processing
@@ -181,7 +210,7 @@ while true; do
     echo "# [${SLURM_JOB_ID}] Iteration $iteration: Starting Processing of warcs" >> "$out"
     python3 -u "$workdir/llm-foundry/data/cc/process_cc_dump_with_quality_filters.py" \
         --config_folder "$CONFIG_FOLDER" \
-        --warc_files_folder "$WARC_FILES_FOLDER" \
+        --warc_files_folder "$active_dir" \
         --logs_folder "$LOGS_FOLDER" \
         --warc_extraction_output "$WARC_EXTRACTION_OUTPUT" \
         --quality_filter_output "$QUALITY_FILTER_OUTPUT" \
@@ -193,9 +222,25 @@ while true; do
         --tokenizer_name_or_path "$TOKENIZER_NAME_OR_PATH" \
         --tasks $SLURM_CPUS_PER_TASK \
         --workers $SLURM_CPUS_PER_TASK 1>>"$out" 2>>"$err" &
-    wait
+    process_pid=$!
 
-    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Processing completed" >> "$out"
+    #############################################
+    # Swap Buffers
+    #############################################
+
+    # Wait for both downloading and processing before swapping, so the staging buffer is complete.
+    wait "$download_pid" "$process_pid"
+
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Processing current warcs completed" >> "$out"
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Downloading warcs for next iteration completed" >> "$out"
+
+    echo "# [${SLURM_JOB_ID}] Iteration $iteration: Swapping buffers" >> "$out"
+
+    # Swapping buffers
+    tmp="$active_dir"; active_dir="$staging_dir"; staging_dir="$tmp"
+
+    # Clear the just-consumed buffer for its next reuse.
+    find "$staging_dir" -mindepth 1 -delete 2>/dev/null || true
 
     #############################################
     # Split Large JSONL Files
@@ -227,7 +272,6 @@ while true; do
     # Delete the content of temporary folders
     #############################################
     echo "# [${SLURM_JOB_ID}] Iteration $iteration: Cleaning up temporary files" >> "$out"
-    find "$WARC_FILES_FOLDER" -mindepth 1 -delete 2>/dev/null || true
     find "$LOGS_FOLDER" -mindepth 1 -delete 2>/dev/null || true
     find "$WARC_EXTRACTION_OUTPUT" -mindepth 1 -delete 2>/dev/null || true
     find "$QUALITY_FILTER_OUTPUT" -mindepth 1 -delete 2>/dev/null || true
@@ -266,6 +310,11 @@ while true; do
     # Brief pause between iterations
     sleep 60
 done
+
+# Clear buffers
+echo "# [${SLURM_JOB_ID}] Clearing buffers" >> "$out"
+find "$WARC_BUFFER_A" -mindepth 1 -delete 2>/dev/null || true
+find "$WARC_BUFFER_B" -mindepth 1 -delete 2>/dev/null || true
 
 #############################################
 # End of Script

--- a/data/cc/warc_files_download.sh
+++ b/data/cc/warc_files_download.sh
@@ -12,11 +12,12 @@
 #   Run warc_paths_get.sh first to download the warc.paths index file
 #
 # Usage:
-#   bash warc_files_download.sh [number_of_files] [cc_dump] [OPTIONS]
+#   bash warc_files_download.sh [number_of_files] [cc_dump] --download-dir [directory] [OPTIONS]
 #
 # Arguments:
 #   number_of_files  - How many WARC files to download (optional, default: all)
 #   cc_dump          - Common Crawl dump identifier (optional, default: CC-MAIN-2025-30)
+#   --download-dir [directory]    - Base directory for downloads (optional, default: ./common_crawl/CC-MAIN-2025-30)
 #
 # Options:
 #   --remove-downloaded  - Remove successfully downloaded paths from warc.paths file
@@ -49,13 +50,23 @@
 REMOVE_DOWNLOADED=false                    # <-- Flag to remove downloaded paths from index
 NUM_FILES=""                               # <-- Number of files to download (empty = all)
 CC_DUMP_ARG=""                             # <-- Common Crawl dump identifier
+DOWNLOAD_DIR=""                            # <-- Base directory for downloads
 
 # Parse command line arguments
 # Loop through all arguments and categorize them
 for arg in "$@"; do
+    if [ "$PREV_ARG" = "--download-dir" ]; then
+        DOWNLOAD_DIR="$arg"
+        PREV_ARG=""
+        continue
+    fi
+
     case $arg in
         --remove-downloaded)
             REMOVE_DOWNLOADED=true         # <-- Enable path removal feature
+            ;;
+        --download-dir)
+            PREV_ARG="--download-dir"       # <-- Base download directory. Will be set in the next iteration
             ;;
         *)
             # Assign positional arguments in order
@@ -75,7 +86,7 @@ done
 CC_DUMP=${CC_DUMP_ARG:-"CC-MAIN-2025-30"}                 # <-- Change default dump if desired
 
 # Define directory structure
-DOWNLOAD_DIR="./common_crawl/$CC_DUMP/warc_files"         # <-- Where WARC files are saved
+DOWNLOAD_DIR=${DOWNLOAD_DIR:-"./common_crawl/$CC_DUMP"}  # <-- Where WARC files are saved
 WARC_PATHS_FILE="./common_crawl/$CC_DUMP/warc.paths"      # <-- Index file with WARC paths
 TEMP_PATHS_FILE="./common_crawl/$CC_DUMP/warc.paths.tmp"  # <-- Temporary file for updates
 BASE_URL="https://data.commoncrawl.org"                   # <-- Common Crawl base URL
@@ -90,6 +101,7 @@ mkdir -p "$DOWNLOAD_DIR"                   # <-- Creates nested directories if n
 echo ""
 echo "=== WARC Download Started at $(date) ==="
 echo "CC_DUMP: $CC_DUMP"
+echo "WARC file download directory: $DOWNLOAD_DIR"
 if [ "$REMOVE_DOWNLOADED" = true ]; then
     echo "Remove downloaded paths: ENABLED (paths will be removed from warc.paths)"
 else


### PR DESCRIPTION

# What does this PR do?

<!--
Thanks for your contribution! 🎉

Please replace this comment with a clear description of:
- What change you made and why
- Which issue is fixed (if applicable)
- Any relevant motivation and context
- Any new dependencies introduced by this change

The title of this PR will be used when your change is referenced, so make sure it is clear and descriptive.
-->


Fixes #52 

- Changes time management function `get_remaining_seconds()` in `data/cc/slurm/process_cc_dump_all_languages.sh` and `../process_cc_dump_with_quality_filters.sh` to use SLURM_JOB_END_TIME to fix parsing error.
- Adds command line parameter `--download-dir` to `CAISA/llm-foundry/data/cc/warc_files_download.sh` to specify download directory for WARC files.
- Adds buffer to overlap downloading and processing in `data/cc/slurm/process_cc_dump_all_languages.sh` and `../process_cc_dump_with_quality_filters.sh`. In each iteration, the next batch of WARC files are downloaded while the current batch is being processed.


## Before submitting
- [x] I have read [CONTRIBUTING.md](https://github.com/Polygl0t/llm-foundry/blob/main/CONTRIBUTING.md).
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] The change was discussed/approved via a GitHub issue (please add a link if so).
- [x] The title and description clearly explain what was changed and why.
- [x] Commits have been squashed into a single, clean commit.
- [x] Existing tests still pass (`pytest` from the repository root).
- [ ] New functionality is covered by tests (if applicable).
- [x] I have run `pre-commit run --all-files` and fixed any issues.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to @-mention
the maintainers (@Nkluge-correa or @shiza-fatimah) or other contributors who may be interested in
your PR.
