### PR TITLE
datasets split_train_val() parameter error

### DIFF
--- a/data/filters/train_annotator.py
+++ b/data/filters/train_annotator.py
@@ -150,7 +150,7 @@ def main(args):
     # Split the dataset into train and test sets.
     dataset = dataset.train_test_split(
         test_size=min(
-            args.test_size, len(dataset) * 0.1
+            args.test_size, int(len(dataset) * 0.1)
         ),  # Ensure test_size doesn't exceed dataset size
         seed=args.seed,
         stratify_by_column=args.target_column,


### PR DESCRIPTION

# What does this PR do?

<!--
Thanks for your contribution! 🎉

Please replace this comment with a clear description of:
- What change you made and why
- Which issue is fixed (if applicable)
- Any relevant motivation and context
- Any new dependencies introduced by this change

The title of this PR will be used when your change is referenced, so make sure it is clear and descriptive.
-->

<!-- Remove if not applicable -->

Fixes #57 

Casts parameter to `int` before calling `datasets.Dataset.train_test_split()` to prevent parameter type error.

## Before submitting
- [x] I have read [CONTRIBUTING.md](https://github.com/Polygl0t/llm-foundry/blob/main/CONTRIBUTING.md).
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] The change was discussed/approved via a GitHub issue (please add a link if so).
- [x] The title and description clearly explain what was changed and why.
- [x] Commits have been squashed into a single, clean commit.
- [x] Existing tests still pass (`pytest` from the repository root).
- [ ] New functionality is covered by tests (if applicable).
- [x] I have run `pre-commit run --all-files` and fixed any issues.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to @-mention
the maintainers (@Nkluge-correa or @shiza-fatimah) or other contributors who may be interested in
your PR.
